### PR TITLE
CompositeException rewrite

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,6 @@
             <artifactId>sourcecode_2.11</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.11</artifactId>
         </dependency>

--- a/src/main/scala/nl/knaw/dans/lib/error/CompositeException.scala
+++ b/src/main/scala/nl/knaw/dans/lib/error/CompositeException.scala
@@ -28,7 +28,7 @@ import scala.language.postfixOps
  *
  * @param throwables a collection of `Throwable`s
  */
-class CompositeException(private val throwables: Seq[Throwable]) extends RuntimeException {
+class CompositeException(private val throwables: Throwable*) extends RuntimeException {
 
   @tailrec
   private def flattenExceptions(throwables: Seq[Throwable], result: mutable.ListBuffer[Throwable] = mutable.ListBuffer.empty): Seq[Throwable] = {
@@ -141,7 +141,7 @@ class CompositeException(private val throwables: Seq[Throwable]) extends Runtime
 }
 
 object CompositeException {
-  def apply(errors: Throwable*): CompositeException = new CompositeException(errors)
+  def apply(errors: Seq[Throwable]): CompositeException = new CompositeException(errors:_*)
 
   def unapply(arg: CompositeException): Option[Seq[Throwable]] = Option(arg.throwables)
 }

--- a/src/main/scala/nl/knaw/dans/lib/error/CompositeException.scala
+++ b/src/main/scala/nl/knaw/dans/lib/error/CompositeException.scala
@@ -1,0 +1,131 @@
+package nl.knaw.dans.lib.error
+
+import java.io.{ PrintStream, PrintWriter }
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+/**
+ * An exception that bundles a collection of `Throwable`s.
+ *
+ * The exception message returns the concatenation of all the `Throwable`s' messages.
+ *
+ * @param throwables a collection of `Throwable`s
+ */
+class CompositeException(private val throwables: Seq[Throwable]) extends RuntimeException {
+
+  @tailrec
+  private def flattenExceptions(throwables: Seq[Throwable], result: mutable.ListBuffer[Throwable] = mutable.ListBuffer.empty): Seq[Throwable] = {
+    throwables match {
+      case Seq() => result
+      case Seq(CompositeException(ths), tail@_*) => flattenExceptions(ths ++ tail, result)
+      case Seq(th, tail@_*) => flattenExceptions(tail, result += th)
+    }
+  }
+
+  val exceptions: Seq[Throwable] = flattenExceptions(throwables)
+
+  lazy private val msg = exceptions.size match {
+    case 0 => "No exceptions occurred."
+    case 1 => "1 exception occurred."
+    case n => s"$n exceptions occurred."
+  }
+  override def getMessage: String = msg
+
+  lazy private val cause: Throwable = {
+    val emptyThrowable: Throwable = new RuntimeException("Chain of causes for CompositeException In Order Received =>")
+
+    def listCauses(th: Throwable): List[Throwable] = {
+      Option(th.getCause)
+        .filterNot(th ==)
+        .map(root => {
+          Stream.iterate((null: Throwable, root)) {
+            case (_, curr) => (curr, curr.getCause)
+          }.takeWhile {
+            case (prev, curr) => curr != null && curr != prev
+          }.map { case (_, curr) => curr }.toList
+        })
+        .getOrElse(List.empty)
+    }
+
+    def getRootCause(th: Throwable): Throwable = {
+      listCauses(th) match {
+        case Nil => th
+        case cs => cs.last
+      }
+    }
+
+    exceptions.foldLeft((emptyThrowable, Set.empty[Throwable])) {
+      case ((chain, seen), th) if seen contains th => (chain, seen)
+      case ((chain, seen), th) =>
+        // check if any of them have been seen before
+        val (seen2, th2) = listCauses(th).foldLeft((seen + th, th)) {
+          case ((seenThs, _), c) if seenThs contains c =>
+            // already seen this outer Throwable so skip
+            (seenThs, new RuntimeException("Duplicate found in causal chain so cropping to prevent loop ..."))
+          case ((seenThs, e), c) => (seenThs + c, e)
+        }
+
+        // we now have 'th2' as the last in the chain
+        try { chain.initCause(th2) }
+        catch { case _: Throwable => } // discard error
+
+        (getRootCause(chain), seen2)
+    }
+
+    emptyThrowable
+  }
+  override def getCause: Throwable = cause
+
+  override def printStackTrace(): Unit = {
+    printStackTrace(System.err)
+  }
+
+  override def printStackTrace(s: PrintStream): Unit = {
+    s.synchronized {
+      s.println(stackTraceString)
+    }
+  }
+
+  override def printStackTrace(s: PrintWriter): Unit = {
+    s.synchronized {
+      s.println(stackTraceString)
+    }
+  }
+
+  private def stackTraceString: String = {
+    val builder = new StringBuilder(128)
+    builder.append(this).append('\n')
+
+    for (elem <- getStackTrace) {
+      builder.append("\tat ").append(elem).append('\n')
+    }
+
+    for ((ex, i) <- exceptions.zipWithIndex) {
+      builder.append("  ComposedException ").append(i + 1).append(" :\n")
+      appendStackTrace(ex, "\t")
+    }
+
+    @tailrec
+    def appendStackTrace(th: Throwable, prefix: String): Unit = {
+      builder.append(prefix).append(th).append('\n')
+
+      for (elem <- th.getStackTrace) {
+        builder.append("\t\tat ").append(elem).append('\n')
+      }
+
+      if (th.getCause != null) {
+        builder.append("\tCaused by: ")
+        appendStackTrace(th.getCause, "")
+      }
+    }
+
+    builder.toString()
+  }
+}
+
+object CompositeException {
+  def apply(errors: Throwable*): CompositeException = new CompositeException(errors)
+
+  def unapply(arg: CompositeException): Option[Seq[Throwable]] = Option(arg.throwables)
+}

--- a/src/main/scala/nl/knaw/dans/lib/error/CompositeException.scala
+++ b/src/main/scala/nl/knaw/dans/lib/error/CompositeException.scala
@@ -26,9 +26,9 @@ import scala.language.postfixOps
  *
  * The exception message returns the concatenation of all the `Throwable`s' messages.
  *
- * @param throwables a collection of `Throwable`s
+ * @param errors a collection of `Throwable`s
  */
-class CompositeException(private val throwables: Throwable*) extends RuntimeException {
+class CompositeException(private val errors: Throwable*) extends RuntimeException {
 
   @tailrec
   private def flattenExceptions(throwables: Seq[Throwable], result: mutable.ListBuffer[Throwable] = mutable.ListBuffer.empty): Seq[Throwable] = {
@@ -39,9 +39,9 @@ class CompositeException(private val throwables: Throwable*) extends RuntimeExce
     }
   }
 
-  val exceptions: Seq[Throwable] = flattenExceptions(throwables)
+  val throwables: Seq[Throwable] = flattenExceptions(errors)
 
-  lazy private val msg = exceptions.size match {
+  lazy private val msg = throwables.size match {
     case 0 => "No exceptions occurred."
     case 1 => "1 exception occurred."
     case n => s"$n exceptions occurred."
@@ -71,7 +71,7 @@ class CompositeException(private val throwables: Throwable*) extends RuntimeExce
       }
     }
 
-    exceptions.foldLeft((emptyThrowable, Set.empty[Throwable])) {
+    throwables.foldLeft((emptyThrowable, Set.empty[Throwable])) {
       case ((chain, seen), th) if seen contains th => (chain, seen)
       case ((chain, seen), th) =>
         // check if any of them have been seen before
@@ -117,7 +117,7 @@ class CompositeException(private val throwables: Throwable*) extends RuntimeExce
       builder.append("\tat ").append(elem).append('\n')
     }
 
-    for ((ex, i) <- exceptions.zipWithIndex) {
+    for ((ex, i) <- throwables.zipWithIndex) {
       builder.append("  ComposedException ").append(i + 1).append(" :\n")
       appendStackTrace(ex, "\t")
     }

--- a/src/main/scala/nl/knaw/dans/lib/error/CompositeException.scala
+++ b/src/main/scala/nl/knaw/dans/lib/error/CompositeException.scala
@@ -138,6 +138,13 @@ class CompositeException(private val errors: Throwable*) extends RuntimeExceptio
 
     builder.toString()
   }
+
+  override def equals(obj: scala.Any): Boolean = {
+    obj match {
+      case CompositeException(errs) => errors.equals(errs)
+      case _ => false
+    }
+  }
 }
 
 object CompositeException {

--- a/src/main/scala/nl/knaw/dans/lib/error/CompositeException.scala
+++ b/src/main/scala/nl/knaw/dans/lib/error/CompositeException.scala
@@ -1,9 +1,25 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.lib.error
 
 import java.io.{ PrintStream, PrintWriter }
 
 import scala.annotation.tailrec
 import scala.collection.mutable
+import scala.language.postfixOps
 
 /**
  * An exception that bundles a collection of `Throwable`s.

--- a/src/main/scala/nl/knaw/dans/lib/error/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/error/package.scala
@@ -53,7 +53,7 @@ package object error {
      */
     def collectResults(implicit canBuildFrom: CanBuildFrom[Nothing, T, M[T]]): Try[M[T]] = {
       if (xs.exists(_.isFailure))
-        Failure(new CompositeException(xs.flatMap {
+        Failure(CompositeException(xs.flatMap {
           case Success(_) => Seq.empty
           case Failure(CompositeException(ts)) => ts
           case Failure(e) => Seq(e)

--- a/src/main/scala/nl/knaw/dans/lib/error/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/error/package.scala
@@ -15,25 +15,11 @@
  */
 package nl.knaw.dans.lib
 
-import org.apache.commons.lang.exception.ExceptionUtils._
-
 import scala.collection.generic.CanBuildFrom
 import scala.language.higherKinds
 import scala.util.{Failure, Success, Try}
 
 package object error {
-
-  /**
-   * An exception that bundles a collection of `Throwable`s.
-   *
-   * The exception message returns the concatenation of all the `Throwable`s' messages.
-   *
-   * @param throwables a collection of `Throwable`s
-   */
-  case class CompositeException(throwables: Traversable[Throwable])
-    extends RuntimeException(throwables.foldLeft("")(
-      (msg, t) => s"$msg\n${getMessage(t)} ${getStackTrace(t)}"
-    ))
 
   implicit class TraversableTryExtensions[M[_], T](xs: M[Try[T]])(implicit ev: M[Try[T]] <:< Traversable[Try[T]]) {
     /**
@@ -67,11 +53,11 @@ package object error {
      */
     def collectResults(implicit canBuildFrom: CanBuildFrom[Nothing, T, M[T]]): Try[M[T]] = {
       if (xs.exists(_.isFailure))
-        Failure(CompositeException(xs.flatMap {
-          case Success(_) => Traversable.empty
+        Failure(new CompositeException(xs.flatMap {
+          case Success(_) => Seq.empty
           case Failure(CompositeException(ts)) => ts
-          case Failure(e) => Traversable(e)
-        }))
+          case Failure(e) => Seq(e)
+        }.toSeq))
       else
         Success(xs.map(_.get).to(canBuildFrom))
     }

--- a/src/test/scala/nl/knaw/dans/lib/error/CompositeExceptionSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/error/CompositeExceptionSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.lib.error
 
 import java.io.{ PrintWriter, StringWriter }
@@ -28,10 +43,6 @@ class CompositeExceptionSpec extends FlatSpec with Matchers {
     val ce1 = CompositeException(ex4, ex5)
     val ce2 = CompositeException(ce1, ex6)
     ce2.getMessage shouldBe "3 exceptions occurred."
-  }
-
-  private def traverseCauses(ex: Throwable): Seq[Throwable] = {
-    Stream.iterate(ex)(_.getCause).takeWhile(null !=)
   }
 
   "getCause" should "return a chain of causes" in {

--- a/src/test/scala/nl/knaw/dans/lib/error/CompositeExceptionSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/error/CompositeExceptionSpec.scala
@@ -28,7 +28,7 @@ class CompositeExceptionSpec extends FlatSpec with Matchers {
     val ex4 = new Exception("msg4", ex3)
     val ex5 = new Exception("msg5")
 
-    val ce = CompositeException(ex4, ex5)
+    val ce = new CompositeException(ex4, ex5)
     ce.getMessage shouldBe "2 exceptions occurred."
   }
 
@@ -40,8 +40,8 @@ class CompositeExceptionSpec extends FlatSpec with Matchers {
     val ex5 = new Exception("msg5")
     val ex6 = new Exception("msg6")
 
-    val ce1 = CompositeException(ex4, ex5)
-    val ce2 = CompositeException(ce1, ex6)
+    val ce1 = new CompositeException(ex4, ex5)
+    val ce2 = new CompositeException(ce1, ex6)
     ce2.getMessage shouldBe "3 exceptions occurred."
   }
 
@@ -52,7 +52,7 @@ class CompositeExceptionSpec extends FlatSpec with Matchers {
     val ex4 = new Exception("msg4", ex3)
     val ex5 = new Exception("msg5")
 
-    val ce = CompositeException(ex4, ex5)
+    val ce = new CompositeException(ex4, ex5)
 
     ce.getCause.getMessage should include("Chain of causes")
     ce.getCause.getCause should have message "msg4"
@@ -66,7 +66,7 @@ class CompositeExceptionSpec extends FlatSpec with Matchers {
   it should "not show duplicated causes" in {
     val ex = new Exception("msg")
 
-    val ce = CompositeException(ex, ex)
+    val ce = new CompositeException(ex, ex)
 
     ce.getCause.getMessage should include("Chain of causes")
     ce.getCause.getCause should have message "msg"
@@ -80,7 +80,7 @@ class CompositeExceptionSpec extends FlatSpec with Matchers {
     val ex4 = new Exception("msg4", ex3)
     val ex5 = new Exception("msg5", ex2)
 
-    val ce = CompositeException(ex4, ex5)
+    val ce = new CompositeException(ex4, ex5)
 
     ce.getCause.getMessage should include("Chain of causes")
     ce.getCause.getCause should have message "msg4"
@@ -98,7 +98,7 @@ class CompositeExceptionSpec extends FlatSpec with Matchers {
     val ex4 = new Exception("msg4", ex3)
     val ex5 = new Exception("msg5")
 
-    val ce = CompositeException(ex4, ex5)
+    val ce = new CompositeException(ex4, ex5)
 
     val stringWriter = new StringWriter
     ce.printStackTrace(new PrintWriter(stringWriter))

--- a/src/test/scala/nl/knaw/dans/lib/error/CompositeExceptionSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/error/CompositeExceptionSpec.scala
@@ -1,0 +1,105 @@
+package nl.knaw.dans.lib.error
+
+import java.io.{ PrintWriter, StringWriter }
+
+import org.scalatest.{ FlatSpec, Matchers }
+
+class CompositeExceptionSpec extends FlatSpec with Matchers {
+
+  "getMessage" should "return the number of exceptions in the CompositeException" in {
+    val ex1 = new Exception("msg1")
+    val ex2 = new Exception("msg2", ex1)
+    val ex3 = new Exception("msg3", ex2)
+    val ex4 = new Exception("msg4", ex3)
+    val ex5 = new Exception("msg5")
+
+    val ce = CompositeException(ex4, ex5)
+    ce.getMessage shouldBe "2 exceptions occurred."
+  }
+
+  it should "flatten nested CompositeExceptions" in {
+    val ex1 = new Exception("msg1")
+    val ex2 = new Exception("msg2", ex1)
+    val ex3 = new Exception("msg3", ex2)
+    val ex4 = new Exception("msg4", ex3)
+    val ex5 = new Exception("msg5")
+    val ex6 = new Exception("msg6")
+
+    val ce1 = CompositeException(ex4, ex5)
+    val ce2 = CompositeException(ce1, ex6)
+    ce2.getMessage shouldBe "3 exceptions occurred."
+  }
+
+  private def traverseCauses(ex: Throwable): Seq[Throwable] = {
+    Stream.iterate(ex)(_.getCause).takeWhile(null !=)
+  }
+
+  "getCause" should "return a chain of causes" in {
+    val ex1 = new Exception("msg1")
+    val ex2 = new Exception("msg2", ex1)
+    val ex3 = new Exception("msg3", ex2)
+    val ex4 = new Exception("msg4", ex3)
+    val ex5 = new Exception("msg5")
+
+    val ce = CompositeException(ex4, ex5)
+
+    ce.getCause.getMessage should include("Chain of causes")
+    ce.getCause.getCause should have message "msg4"
+    ce.getCause.getCause.getCause should have message "msg3"
+    ce.getCause.getCause.getCause.getCause should have message "msg2"
+    ce.getCause.getCause.getCause.getCause.getCause should have message "msg1"
+    ce.getCause.getCause.getCause.getCause.getCause.getCause should have message "msg5"
+    ce.getCause.getCause.getCause.getCause.getCause.getCause.getCause shouldBe null
+  }
+
+  it should "not show duplicated causes" in {
+    val ex = new Exception("msg")
+
+    val ce = CompositeException(ex, ex)
+
+    ce.getCause.getMessage should include("Chain of causes")
+    ce.getCause.getCause should have message "msg"
+    ce.getCause.getCause.getCause shouldBe null
+  }
+
+  it should "terminate when finding duplicate causes" in {
+    val ex1 = new Exception("msg1")
+    val ex2 = new Exception("msg2", ex1)
+    val ex3 = new Exception("msg3", ex2)
+    val ex4 = new Exception("msg4", ex3)
+    val ex5 = new Exception("msg5", ex2)
+
+    val ce = CompositeException(ex4, ex5)
+
+    ce.getCause.getMessage should include("Chain of causes")
+    ce.getCause.getCause should have message "msg4"
+    ce.getCause.getCause.getCause should have message "msg3"
+    ce.getCause.getCause.getCause.getCause should have message "msg2"
+    ce.getCause.getCause.getCause.getCause.getCause should have message "msg1"
+    ce.getCause.getCause.getCause.getCause.getCause.getCause.getMessage should include("Duplicate found in causal chain")
+    ce.getCause.getCause.getCause.getCause.getCause.getCause.getCause shouldBe null
+  }
+
+  "printStackTrace" should "" in {
+    val ex1 = new Exception("msg1")
+    val ex2 = new Exception("msg2", ex1)
+    val ex3 = new Exception("msg3", ex2)
+    val ex4 = new Exception("msg4", ex3)
+    val ex5 = new Exception("msg5")
+
+    val ce = CompositeException(ex4, ex5)
+
+    val stringWriter = new StringWriter
+    ce.printStackTrace(new PrintWriter(stringWriter))
+    val trace = stringWriter.toString
+
+    trace should {
+      include("CompositeException: 2 exceptions occurred") and
+        include("  ComposedException 1 :\n\tjava.lang.Exception: msg4") and
+        include("\tCaused by: java.lang.Exception: msg3") and
+        include("\tCaused by: java.lang.Exception: msg2") and
+        include("\tCaused by: java.lang.Exception: msg1") and
+        include("  ComposedException 2 :\n\tjava.lang.Exception: msg5")
+    }
+  }
+}


### PR DESCRIPTION
#### When applied it will
* completely rewrite the `CompositeException`
    * add better stacktrace formatting
    * build up a causal chain of exceptions which removes duplicates and cycles
* add and fix tests accordingly
* remove the Apache Commons dependency that is no longer needed here

@DANS-KNAW/easy for review

#### Notes
* This code is heavily inspired by [RxJava's `CompositeException`](https://github.com/ReactiveX/RxJava/blob/2.x/src/main/java/io/reactivex/exceptions/CompositeException.java)
* When applied to the various projects that already use the `CompositeException`, it is expected that some tests will fail, since the return message is now different. The interfaces for constructing (`apply`) and deconstructing (`unapply`) a `CompositeException` have, however, remained the same. Other errors are not expected to occur.
* These changes were tested with easy-split-multi-deposit, easy-bag-store and easy-bag-index and none of them indicated any errors during compiling nor testing.