### PR TITLE
simplify collectResults

### DIFF
--- a/src/main/scala/nl/knaw/dans/lib/error/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/error/package.scala
@@ -53,11 +53,7 @@ package object error {
      */
     def collectResults(implicit canBuildFrom: CanBuildFrom[Nothing, T, M[T]]): Try[M[T]] = {
       if (xs.exists(_.isFailure))
-        Failure(CompositeException(xs.flatMap {
-          case Success(_) => Seq.empty
-          case Failure(CompositeException(ts)) => ts
-          case Failure(e) => Seq(e)
-        }.toSeq))
+        Failure(CompositeException(xs.collect { case Failure(e) => e }.toSeq))
       else
         Success(xs.map(_.get).to(canBuildFrom))
     }


### PR DESCRIPTION
~~fixes EASY-~~

#### When applied it will
* remove the extra check for a `CompositeException` in `collectResults`, since it isn't needed anymore by #6, where this is already done in `CompositeException` itself

@DANS-KNAW/easy 