### PR TITLE
Try combine operator

### DIFF
--- a/src/main/scala/nl/knaw/dans/lib/error/CompositeException.scala
+++ b/src/main/scala/nl/knaw/dans/lib/error/CompositeException.scala
@@ -150,5 +150,5 @@ class CompositeException(private val errors: Throwable*) extends RuntimeExceptio
 object CompositeException {
   def apply(errors: Seq[Throwable]): CompositeException = new CompositeException(errors:_*)
 
-  def unapply(arg: CompositeException): Option[Seq[Throwable]] = Option(arg.throwables)
+  def unapply(arg: CompositeException): Option[List[Throwable]] = Option(arg.throwables.toList)
 }

--- a/src/test/scala/nl/knaw/dans/lib/error/CollectResultsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/error/CollectResultsSpec.scala
@@ -48,7 +48,7 @@ class CollectResultsSpec extends FlatSpec with Matchers with Inside {
       Failure(new ArrayIndexOutOfBoundsException("foobar")) :: Success(4) :: Nil
 
     inside(collection.collectResults) {
-      case Failure(CompositeException(Seq(ex: ArrayIndexOutOfBoundsException))) =>
+      case Failure(CompositeException((ex: ArrayIndexOutOfBoundsException) :: Nil)) =>
         ex should have message "foobar"
     }
   }
@@ -58,7 +58,7 @@ class CollectResultsSpec extends FlatSpec with Matchers with Inside {
       Success(3) :: Failure(new NoSuchElementException("bar")) :: Success(5) :: Nil
 
     inside(collection.collectResults) {
-      case Failure(CompositeException(Seq(ex1: IllegalArgumentException, ex2: NoSuchElementException))) =>
+      case Failure(CompositeException((ex1: IllegalArgumentException) :: (ex2: NoSuchElementException) :: Nil)) =>
         ex1 should have message "foo"
         ex2 should have message "bar"
     }
@@ -73,7 +73,7 @@ class CollectResultsSpec extends FlatSpec with Matchers with Inside {
     val result = collection.collectResults
 
     inside(result) {
-      case Failure(CompositeException(Seq(ex1: IllegalArgumentException, ex2: NoSuchElementException, ex3: ArrayIndexOutOfBoundsException))) =>
+      case Failure(CompositeException((ex1: IllegalArgumentException) :: (ex2: NoSuchElementException) :: (ex3: ArrayIndexOutOfBoundsException) :: Nil)) =>
         ex1 should have message "foo"
         ex2 should have message "bar"
         ex3 should have message "baz"


### PR DESCRIPTION
~~fixes EASY-~~

We are already able to transform a `List[Try[T]]` into a `Try[List[T]]` using `collectResults`. However, we are not able combine values of type `Try[T]` into a single value and collect there failures (in case both are `Failure`). Note that a `flatMap` or for-comprehension will not suffice here, since this will first evaluate the left hand side and only evaluate the right hand side if the left hand side is a `Success`.
I recently needed this collecting behavior in easy-split-multi-deposit, implemented it there and thought it would make a good addition to the dans-scala-lib.

See the code for an example, as well as [easy-split-multi-deposit](https://github.com/DANS-KNAW/easy-split-multi-deposit/blob/51d259dbe825b138b18bbee005b7d6cc238114b0/src/main/scala/nl/knaw/dans/easy/multideposit/parser/MetadataParser.scala#L27-L42).

#### When applied it will
* introduce the `combine` operator that is currently used in easy-split-multi-deposit
* add tests accordingly

@DANS-KNAW/easy for review