### PR TITLE
better collectResults behavior

### DIFF
--- a/src/main/scala/nl/knaw/dans/lib/error/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/error/package.scala
@@ -52,10 +52,11 @@ package object error {
      * @return a consolidated result
      */
     def collectResults(implicit canBuildFrom: CanBuildFrom[Nothing, T, M[T]]): Try[M[T]] = {
-      if (xs.exists(_.isFailure))
-        Failure(CompositeException(xs.collect { case Failure(e) => e }.toSeq))
-      else
-        Success(xs.map(_.get).to(canBuildFrom))
+      xs.collect { case Failure(e) => e }.toSeq match {
+        case Seq() => Success(xs.map(_.get).to(canBuildFrom))
+        case Seq(e) => Failure(e)
+        case es => Failure(CompositeException(es))
+      }
     }
   }
 

--- a/src/test/scala/nl/knaw/dans/lib/error/CollectResultsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/error/CollectResultsSpec.scala
@@ -48,7 +48,7 @@ class CollectResultsSpec extends FlatSpec with Matchers with Inside {
       Failure(new ArrayIndexOutOfBoundsException("foobar")) :: Success(4) :: Nil
 
     inside(collection.collectResults) {
-      case Failure(CompositeException((ex: ArrayIndexOutOfBoundsException) :: Nil)) =>
+      case Failure((ex: ArrayIndexOutOfBoundsException)) =>
         ex should have message "foobar"
     }
   }


### PR DESCRIPTION
```scala
(1 to 5).map(i => if (i == 4) Failure(new IllegalArgumentException("I don't like 4")) else Success(i)).collectResults
```
This expression results in a `Failure(CompositeException(new IllegalArgumentException("I don't like 4")))`. I think this is not as it should be, now that I think about it some more. Since only one exception occurred, it should not put that into a `CompositeException`, but rather return it as `Failure(new IllegalArgumentException("I don't like 4"))`.

One of the tests specifically tested for the former behavior, but I now think that's wrong. Shouldn't it be the latter.

In this PR I provide this 'new'/better behavior.

Extra (minor) win: we now only pass through the list `xs: List[Try[T]]` twice instead of thrice!

Note: as far as I can see this change in behavior does not effect the outcome of our systems (tested on easy-bag-store, easy-bag-index and easy-split-multi-deposit).