### PR TITLE
add unsafeGetOrThrow to TryExtensions

### DIFF
--- a/src/main/scala/nl/knaw/dans/lib/error/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/error/package.scala
@@ -198,5 +198,39 @@ package object error {
         case (Failure(e1), Failure(e2)) => Failure(new CompositeException(e1, e2))
       }
     }
+
+    /**
+     * Returns the value inside a `Success` or throws the `Throwable` inside a `Failure`.
+     * Note that this behavior is the same as `Try.get`, but that this explicitly acknowledges the
+     * potential danger of throwing an `Exception`.
+     *
+     * This method should only be used in the exceptional case that throwing the `Exception` is the
+     * only possible solution. The user should have made extra effort to avoid the use of this method
+     * before deciding to use it!
+     *
+     * Example:
+     * {{{
+     *   import nl.knaw.dans.lib.error.TryExtensions
+     *   import java.io.{ File, FileNotFoundException }
+     *   import scala.util.{Failure, Success, Try}
+     *
+     *   def getFileName(file: File): Try[String] =
+     *     if (file.exists) Success(file.getName)
+     *     else Failure(new FileNotFoundException())
+     *
+     *   // Fill in existing or non-existing file
+     *   val file = new File("x")
+     *
+     *   val filename = getFileName(file).unsafeGetOrThrow
+     * }}}
+     *
+     * @return
+     */
+    def unsafeGetOrThrow: T = {
+      t match {
+        case Success(value) => value
+        case Failure(throwable) => throw throwable
+      }
+    }
   }
 }

--- a/src/test/scala/nl/knaw/dans/lib/error/TryExtensionsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/error/TryExtensionsSpec.scala
@@ -166,4 +166,14 @@ class TryExtensionsSpec extends FlatSpec with Matchers with Inside {
         e3 should have message "baz"
     }
   }
+
+  "unsafeGetOrThrow" should "return the value inside a Success" in {
+    Success(5).unsafeGetOrThrow shouldBe 5
+  }
+
+  it should "throw the exception in a Failure" in {
+    val e = new Exception("err msg")
+
+    the[Exception] thrownBy Failure(e).unsafeGetOrThrow shouldBe e
+  }
 }


### PR DESCRIPTION
@DANS-KNAW/easy for review 

This method has been copied to a lot of modules already (including the archetype!), so it is finally time to move it to this library.

Once this PR is merged and a new version of this lib has been published, a new JIRA issue will be created to remove this (and other) methods from the various modules.