### PR TITLE
String extensions

### DIFF
--- a/src/main/scala/nl/knaw/dans/lib/string/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/string/package.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.lib
 
 package object string {

--- a/src/main/scala/nl/knaw/dans/lib/string/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/string/package.scala
@@ -15,5 +15,7 @@ package object string {
       if (s.isBlank) Option.empty
       else Option(s)
     }
+
+    def emptyIfBlank: String = s.toOption.getOrElse("")
   }
 }

--- a/src/main/scala/nl/knaw/dans/lib/string/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/string/package.scala
@@ -7,7 +7,7 @@ package object string {
     def isBlank: Boolean = {
       s match {
         case null | "" => true
-        case _ => s.exists(!Character.isWhitespace(_))
+        case _ => s.forall(Character.isWhitespace)
       }
     }
 

--- a/src/main/scala/nl/knaw/dans/lib/string/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/string/package.scala
@@ -19,6 +19,11 @@ package object string {
 
   implicit class StringExtensions(val s: String) extends AnyVal {
 
+    /**
+     * Return true when all characters in the `String` are classified as ''whitespace'', false otherwise.
+     *
+     * @return whether all characters are whitespace
+     */
     def isBlank: Boolean = {
       s match {
         case null | "" => true
@@ -26,11 +31,21 @@ package object string {
       }
     }
 
+    /**
+     * Wraps the `String` in an `Option` and returns `Option.empty` if all characters are ''whitespace''.
+     *
+     * @return `None` if all characters are whitespace, `Some(s)` otherwise
+     */
     def toOption: Option[String] = {
       if (s.isBlank) Option.empty
       else Option(s)
     }
 
+    /**
+     * Returns the empty `String` if all characters are ''whitespace'', the original `String` otherwise.
+     *
+     * @return the empty `String` if all characters are ''whitespace'', the input otherwise
+     */
     def emptyIfBlank: String = s.toOption.getOrElse("")
   }
 }

--- a/src/main/scala/nl/knaw/dans/lib/string/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/string/package.scala
@@ -1,0 +1,19 @@
+package nl.knaw.dans.lib
+
+package object string {
+
+  implicit class StringExtensions(val s: String) extends AnyVal {
+
+    def isBlank: Boolean = {
+      s match {
+        case null | "" => true
+        case _ => s.exists(!Character.isWhitespace(_))
+      }
+    }
+
+    def toOption: Option[String] = {
+      if (s.isBlank) Option.empty
+      else Option(s)
+    }
+  }
+}

--- a/src/main/scala/nl/knaw/dans/lib/string/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/string/package.scala
@@ -20,9 +20,10 @@ package object string {
   implicit class StringExtensions(val s: String) extends AnyVal {
 
     /**
-     * Return true when all characters in the `String` are classified as ''whitespace'', false otherwise.
+     * Return true when all characters in the `String` are classified as ''whitespace'' or if
+     * the `String` is `null`, false otherwise.
      *
-     * @return whether all characters are whitespace
+     * @return whether whether the `String` is `null` or all characters are ''whitespace''
      */
     def isBlank: Boolean = {
       s match {
@@ -32,9 +33,10 @@ package object string {
     }
 
     /**
-     * Wraps the `String` in an `Option` and returns `Option.empty` if all characters are ''whitespace''.
+     * Wraps the `String` in an `Option` and returns `Option.empty` if all characters are ''whitespace''
+     * or if the `String` is `null`.
      *
-     * @return `None` if all characters are whitespace, `Some(s)` otherwise
+     * @return `None` if all characters are whitespace or if the `String` is `null`, `Some(s)` otherwise
      */
     def toOption: Option[String] = {
       if (s.isBlank) Option.empty
@@ -42,9 +44,11 @@ package object string {
     }
 
     /**
-     * Returns the empty `String` if all characters are ''whitespace'', the original `String` otherwise.
+     * Returns the empty `String` if all characters are ''whitespace'' or if the `String` is `null`,
+     * the original `String` otherwise.
      *
-     * @return the empty `String` if all characters are ''whitespace'', the input otherwise
+     * @return the empty `String` if all characters are ''whitespace'' or if the `String` is `null`,
+     *         the input otherwise
      */
     def emptyIfBlank: String = s.toOption.getOrElse("")
   }

--- a/src/test/scala/nl/knaw/dans/lib/string/StringExtensionsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/string/StringExtensionsSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.lib.string
 
 import org.scalatest.{ FlatSpec, Matchers, OptionValues }

--- a/src/test/scala/nl/knaw/dans/lib/string/StringExtensionsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/string/StringExtensionsSpec.scala
@@ -4,6 +4,31 @@ import org.scalatest.{ FlatSpec, Matchers, OptionValues }
 
 class StringExtensionsSpec extends FlatSpec with Matchers with OptionValues {
 
+  "isBlank" should "return true when given an empty String" in {
+    "".isBlank shouldBe true
+  }
+
+  it should "return true when the input is null" in {
+    (null: String).isBlank shouldBe true
+  }
+
+  it should "return true when given a String with spaces only" in {
+    "   ".isBlank shouldBe true
+  }
+
+  it should "return true when given a String with tabs, spaces, newlines, etc" in {
+    " \t  \r  \t \n  ".isBlank shouldBe true
+  }
+
+  it should "return false when given a non-blank String" in {
+    "abc".isBlank shouldBe false
+  }
+
+  it should "return false when the input contains both blank and non-blank characters" in {
+    val input = "ab c "
+    input.isBlank shouldBe false
+  }
+
   "toOption" should "return an Option.empty when given an empty String" in {
     "".toOption shouldBe empty
   }
@@ -20,12 +45,37 @@ class StringExtensionsSpec extends FlatSpec with Matchers with OptionValues {
     " \t  \r  \t \n  ".toOption shouldBe empty
   }
 
-  it should "return the original String wrapped in Option when given a non-blank String" in {
+  it should "return the original String wrapped in an Option when given a non-blank String" in {
     "abc".toOption.value shouldBe "abc"
+  }
+
+  it should "return the original String wrapped in an Option when the input contains both blank and non-blank characters" in {
+    val input = "ab c "
+    input.toOption.value shouldBe input
+  }
+
+  "emptyIfBlank" should "return an empty String when given an empty String" in {
+    "".emptyIfBlank shouldBe empty
+  }
+
+  it should "return an empty String when the input is null" in {
+    (null: String).emptyIfBlank shouldBe empty
+  }
+
+  it should "return an empty String when given a String with spaces only" in {
+    "   ".emptyIfBlank shouldBe empty
+  }
+
+  it should "return an empty String when given a String with tabs, spaces, newlines, etc" in {
+    " \t  \r  \t \n  ".emptyIfBlank shouldBe empty
+  }
+
+  it should "return the original String when given a non-blank String" in {
+    "abc".emptyIfBlank shouldBe "abc"
   }
 
   it should "return the original String when the input contains both blank and non-blank characters" in {
     val input = "ab c "
-    input.toOption.value shouldBe input
+    input.emptyIfBlank shouldBe input
   }
 }

--- a/src/test/scala/nl/knaw/dans/lib/string/StringExtensionsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/string/StringExtensionsSpec.scala
@@ -1,0 +1,31 @@
+package nl.knaw.dans.lib.string
+
+import org.scalatest.{ FlatSpec, Matchers, OptionValues }
+
+class StringExtensionsSpec extends FlatSpec with Matchers with OptionValues {
+
+  "toOption" should "return an Option.empty when given an empty String" in {
+    "".toOption shouldBe empty
+  }
+
+  it should "return an Option.empty when the input is null" in {
+    (null: String).toOption shouldBe empty
+  }
+
+  it should "return an Option.empty when given a String with spaces only" in {
+    "   ".toOption shouldBe empty
+  }
+
+  it should "return an Option.empty when given a String with tabs, spaces, newlines, etc" in {
+    " \t  \r  \t \n  ".toOption shouldBe empty
+  }
+
+  it should "return the original String wrapped in Option when given a non-blank String" in {
+    "abc".toOption.value shouldBe "abc"
+  }
+
+  it should "return the original String when the input contains both blank and non-blank characters" in {
+    val input = "ab c "
+    input.toOption.value shouldBe input
+  }
+}


### PR DESCRIPTION
@DANS-KNAW/easy for review

some utility methods on `String` that we frequently use in various EASY modules. These were first introduced in `easy-split-multi-deposit` and later copied to a couple more places.

Once this PR is merged and a new version of this lib has been published, a new JIRA issue will be created to remove this (and other) methods from the various modules.

* [x] implement methods
* [x] test methods
* [x] document methods