### PR TITLE
EASY-1411: introducing Scala 2.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>nl.knaw.dans.lib</groupId>
-    <artifactId>dans-scala-lib</artifactId>
+    <artifactId>dans-scala-lib_2.12</artifactId>
     <version>1.x-SNAPSHOT</version>
 
     <inceptionYear>2016</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -18,35 +18,50 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>nl.knaw.dans.shared</groupId>
-        <artifactId>dans-scala-prototype</artifactId>
-        <version>1.32</version>
-    </parent>
+
     <groupId>nl.knaw.dans.lib</groupId>
     <artifactId>dans-scala-lib</artifactId>
     <version>1.x-SNAPSHOT</version>
+
     <inceptionYear>2016</inceptionYear>
     <name>DANS Scala Library</name>
     <description>Library with generic extensions for Scala-based DANS modules</description>
+
     <scm>
         <developerConnection>scm:git:https://github.com/DANS-KNAW/${project.artifactId}</developerConnection>
         <tag>HEAD</tag>
     </scm>
+
+    <properties>
+        <java.version>1.6</java.version>
+        <scala.compatVersion>2.11</scala.compatVersion>
+        <scala.version>2.11.7</scala.version>
+        <main-class>NoMainClass</main-class>
+    </properties>
+
     <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>2.11.7</version>
+        </dependency>
         <dependency>
             <groupId>com.typesafe.scala-logging</groupId>
             <artifactId>scala-logging_2.11</artifactId>
+            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.lihaoyi</groupId>
             <artifactId>sourcecode_2.11</artifactId>
+            <version>0.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.11</artifactId>
+            <version>2.2.1</version>
         </dependency>
     </dependencies>
+
     <repositories>
         <repository>
             <id>DANS</id>
@@ -56,6 +71,7 @@
             <url>http://maven.dans.knaw.nl/</url>
         </repository>
     </repositories>
+
     <pluginRepositories>
         <pluginRepository>
             <id>DANS</id>
@@ -65,22 +81,190 @@
             <url>http://maven.dans.knaw.nl/</url>
         </pluginRepository>
     </pluginRepositories>
+
     <build>
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
+
         <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>compile</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>test-compile</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.8</version>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>nl.knaw.dans.shared</groupId>
+                                    <artifactId>dans-build-resources</artifactId>
+                                    <version>2.2.0</version>
+                                    <outputDirectory>${project.build.directory}/dans-build-resources</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includePom>true</includePom>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                            <goal>doc-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <scalaCompatVersion>${scala.compatVersion}</scalaCompatVersion>
+                    <scalaVersion>${scala.version}</scalaVersion>
+                    <args>
+                        <arg>-target:jvm-1.8</arg>
+                        <arg>-deprecation</arg>
+                        <arg>-feature</arg>
+                    </args>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.jfrog.buildinfo</groupId>
                 <artifactId>artifactory-maven-plugin</artifactId>
+                <version>2.4.1</version>
+                <executions>
+                    <execution>
+                        <id>build-info</id>
+                        <goals>
+                            <goal>publish</goal>
+                        </goals>
+                        <configuration>
+                            <publisher>
+                                <contextUrl>http://maven-repo.dans.knaw.nl</contextUrl>
+                                <username>{{ ARTIFACTORY_USER }}</username>
+                                <password>{{ ARTIFACTORY_PW }}</password>
+                                <repoKey>libs-release-local</repoKey>
+                                <snapshotRepoKey>libs-snapshot-local</snapshotRepoKey>
+                            </publisher>
+                        </configuration>
+                    </execution>
+                </executions>
+                <inherited>true</inherited>
             </plugin>
+
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
+                <version>2.11</version>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <header>${project.build.directory}/dans-build-resources/license/apache2.txt</header>
+                    <properties>
+                        <owner>DANS - Data Archiving and Networked Services</owner>
+                        <email>info@dans.knaw.nl</email>
+                    </properties>
+                    <excludes>
+                        <exclude>LICENSE</exclude>
+                        <exclude>**/README</exclude>
+                        <exclude>*.sc</exclude>
+                        <exclude>src/main/resources/**</exclude>
+                        <exclude>src/test/resources/**</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
+
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.2</version>
+                <configuration>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                    <developmentVersion>1.x-SNAPSHOT</developmentVersion>
+                    <pushChanges>false</pushChanges>
+                </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
+                <version>1.0</version>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                    <junitxml>.</junitxml>
+                    <filereports>WDF TestSuite.txt</filereports>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <finalName>${project.artifactId}</finalName>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>../lib/</classpathPrefix>
+                            <mainClass>${main-class}</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>nl.knaw.dans.lib</groupId>
@@ -60,6 +61,7 @@
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_2.12</artifactId>
             <version>3.0.4</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -109,6 +111,7 @@
             </plugin>
 
             <plugin>
+                <!-- necessary for the license header in each file -->
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>2.8</version>
                 <executions>
@@ -122,7 +125,7 @@
                                 <artifactItem>
                                     <groupId>nl.knaw.dans.shared</groupId>
                                     <artifactId>dans-build-resources</artifactId>
-                                    <version>2.2.0</version>
+                                    <version>2.3.1</version>
                                     <outputDirectory>${project.build.directory}/dans-build-resources</outputDirectory>
                                 </artifactItem>
                             </artifactItems>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
         <java.version>1.8</java.version>
         <scala.compatVersion>2.12</scala.compatVersion>
         <scala.version>2.12.3</scala.version>
-        <main-class>NoMainClass</main-class>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,32 +33,33 @@
     </scm>
 
     <properties>
-        <java.version>1.6</java.version>
-        <scala.compatVersion>2.11</scala.compatVersion>
-        <scala.version>2.11.7</scala.version>
+        <java.version>1.8</java.version>
+        <scala.compatVersion>2.12</scala.compatVersion>
+        <scala.version>2.12.3</scala.version>
         <main-class>NoMainClass</main-class>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.11.7</version>
+            <version>${scala.version}</version>
         </dependency>
         <dependency>
             <groupId>com.typesafe.scala-logging</groupId>
-            <artifactId>scala-logging_2.11</artifactId>
-            <version>3.4.0</version>
+            <artifactId>scala-logging_2.12</artifactId>
+            <version>3.7.2</version>
         </dependency>
         <dependency>
             <groupId>com.lihaoyi</groupId>
-            <artifactId>sourcecode_2.11</artifactId>
-            <version>0.1.1</version>
+            <artifactId>sourcecode_2.12</artifactId>
+            <version>0.1.4</version>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.11</artifactId>
-            <version>2.2.1</version>
+            <artifactId>scalatest_2.12</artifactId>
+            <version>3.0.4</version>
         </dependency>
     </dependencies>
 
@@ -103,7 +104,7 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
-                    <encoding>UTF-8</encoding>
+                    <encoding>${project.build.sourceEncoding}</encoding>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,12 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>nl.knaw.dans.shared</groupId>
+        <artifactId>dans-prototype</artifactId>
+        <version>1.63</version>
+    </parent>
+
     <groupId>nl.knaw.dans.lib</groupId>
     <artifactId>dans-scala-lib_2.12</artifactId>
     <version>1.x-SNAPSHOT</version>
@@ -90,66 +96,19 @@
 
         <plugins>
             <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <phase>compile</phase>
-                    </execution>
-                    <execution>
-                        <id>default-testCompile</id>
-                        <phase>test-compile</phase>
-                    </execution>
-                </executions>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
+                <groupId>org.jfrog.buildinfo</groupId>
+                <artifactId>artifactory-maven-plugin</artifactId>
             </plugin>
-
             <plugin>
-                <!-- necessary for the license header in each file -->
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
-                <executions>
-                    <execution>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>nl.knaw.dans.shared</groupId>
-                                    <artifactId>dans-build-resources</artifactId>
-                                    <version>2.3.1</version>
-                                    <outputDirectory>${project.build.directory}/dans-build-resources</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
             </plugin>
-
             <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <includePom>true</includePom>
-                </configuration>
+                <artifactId>maven-release-plugin</artifactId>
             </plugin>
-
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
@@ -173,69 +132,6 @@
                     </args>
                 </configuration>
             </plugin>
-
-            <plugin>
-                <groupId>org.jfrog.buildinfo</groupId>
-                <artifactId>artifactory-maven-plugin</artifactId>
-                <version>2.4.1</version>
-                <executions>
-                    <execution>
-                        <id>build-info</id>
-                        <goals>
-                            <goal>publish</goal>
-                        </goals>
-                        <configuration>
-                            <publisher>
-                                <contextUrl>http://maven-repo.dans.knaw.nl</contextUrl>
-                                <username>{{ ARTIFACTORY_USER }}</username>
-                                <password>{{ ARTIFACTORY_PW }}</password>
-                                <repoKey>libs-release-local</repoKey>
-                                <snapshotRepoKey>libs-snapshot-local</snapshotRepoKey>
-                            </publisher>
-                        </configuration>
-                    </execution>
-                </executions>
-                <inherited>true</inherited>
-            </plugin>
-
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>2.11</version>
-                <executions>
-                    <execution>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <header>${project.build.directory}/dans-build-resources/license/apache2.txt</header>
-                    <properties>
-                        <owner>DANS - Data Archiving and Networked Services</owner>
-                        <email>info@dans.knaw.nl</email>
-                    </properties>
-                    <excludes>
-                        <exclude>LICENSE</exclude>
-                        <exclude>**/README</exclude>
-                        <exclude>*.sc</exclude>
-                        <exclude>src/main/resources/**</exclude>
-                        <exclude>src/test/resources/**</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.2</version>
-                <configuration>
-                    <tagNameFormat>v@{project.version}</tagNameFormat>
-                    <developmentVersion>1.x-SNAPSHOT</developmentVersion>
-                    <pushChanges>false</pushChanges>
-                </configuration>
-            </plugin>
-
             <plugin>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
@@ -252,21 +148,6 @@
                     <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     <junitxml>.</junitxml>
                     <filereports>WDF TestSuite.txt</filereports>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
-                <configuration>
-                    <finalName>${project.artifactId}</finalName>
-                    <archive>
-                        <manifest>
-                            <addClasspath>true</addClasspath>
-                            <classpathPrefix>../lib/</classpathPrefix>
-                            <mainClass>${main-class}</mainClass>
-                        </manifest>
-                    </archive>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/scala/nl/knaw/dans/lib/error/CompositeException.scala
+++ b/src/main/scala/nl/knaw/dans/lib/error/CompositeException.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/lib/error/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/error/package.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/scala/nl/knaw/dans/lib/logging/DebugEnhancedLogging.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/DebugEnhancedLogging.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/nl/knaw/dans/lib/error/CollectResultsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/error/CollectResultsSpec.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/nl/knaw/dans/lib/error/CompositeExceptionSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/error/CompositeExceptionSpec.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/scala/nl/knaw/dans/lib/error/CompositeExceptionSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/error/CompositeExceptionSpec.scala
@@ -91,7 +91,7 @@ class CompositeExceptionSpec extends FlatSpec with Matchers {
     ce.getCause.getCause.getCause.getCause.getCause.getCause.getCause shouldBe null
   }
 
-  "printStackTrace" should "" in {
+  "printStackTrace" should "include the messeges (and stacktraces) of all exceptions in the composite exception" in {
     val ex1 = new Exception("msg1")
     val ex2 = new Exception("msg2", ex1)
     val ex3 = new Exception("msg3", ex2)

--- a/src/test/scala/nl/knaw/dans/lib/error/CompositeExceptionSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/error/CompositeExceptionSpec.scala
@@ -91,7 +91,7 @@ class CompositeExceptionSpec extends FlatSpec with Matchers {
     ce.getCause.getCause.getCause.getCause.getCause.getCause.getCause shouldBe null
   }
 
-  "printStackTrace" should "include the messeges (and stacktraces) of all exceptions in the composite exception" in {
+  "printStackTrace" should "include the messages (and stacktraces) of all exceptions in the composite exception" in {
     val ex1 = new Exception("msg1")
     val ex2 = new Exception("msg2", ex1)
     val ex3 = new Exception("msg3", ex2)

--- a/src/test/scala/nl/knaw/dans/lib/error/TryExtensionsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/error/TryExtensionsSpec.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Fixes EASY-1411

@DANS-KNAW/easy for review

This is the first step into moving EASY's Scala modules from Scala 2.11 to 2.12. In order to make this switch, all dependencies must be compiled with Scala 2.12.

Until now, this library inherited from the `dans-prototype` parent-project, while at the same time `dans-prototype` also has a dependency on this library. To break this cyclic dependency, I removed the inheritance from `dans-prototype` and put the necessary plugins in this `pom.xml`.

Furthermore, to keep up with Scala conventions, I renamed the artifactId to `dans-scala-lib_2.12`.

### Special review request
@janvanmansum Please check extra if I didn't miss any Maven plugins (e.g. whether I copied everything correctly)

#### Next steps
* [x] merge https://github.com/DANS-KNAW/dans-parent/pull/29 before proceeding with this PR
* after review, merge this PR, #10, #11 and an additional PR by @janvanmansum 
* make a new release of this library **(please note: the artifactId changed!!!)**