### PR TITLE
EASY-1992 mask IPv6 addresses

### DIFF
--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/AbstractServletLoggerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/AbstractServletLoggerSpec.scala
@@ -56,7 +56,7 @@ class AbstractServletLoggerSpec extends FlatSpec with Matchers with EmbeddedJett
   }
 
   "custom request formatter" should "alter logged content" in {
-    shouldDivertLogging(maskedLoggersPath, formattedRemote = "**.**.**.1")
+    shouldDivertLogging(maskedLoggersPath)
   }
 
   private def shouldDivertLogging(path: String = "/", formattedRemote: String = "127.0.0.1") = {

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/RequestLogFormatterSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/RequestLogFormatterSpec.scala
@@ -59,6 +59,6 @@ class RequestLogFormatterSpec extends FlatSpec with Matchers with MockFactory wi
 
   it should "mask everything when using the MaskedRequestLogFormatter" in {
     (new TestServlet() with MaskedRequestLogFormatter).formatRequestLog shouldBe
-      "GET http://does.not.exist.dans.knaw.nl remote=**.**.**.78; params=[password -> [*****], login -> [*****]]; headers=[cookie -> [scentry.auth.default.user=****.****.****], HTTP_AUTHORIZATION -> [basic *****], foo -> [bar]]"
+      "GET http://does.not.exist.dans.knaw.nl remote=12.**.**.**; params=[password -> [*****], login -> [*****]]; headers=[cookie -> [scentry.auth.default.user=****.****.****], HTTP_AUTHORIZATION -> [basic *****], foo -> [bar]]"
   }
 }

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/RequestLogFormatterSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/RequestLogFormatterSpec.scala
@@ -58,6 +58,6 @@ class RequestLogFormatterSpec extends FlatSpec with Matchers with MockFactory wi
 
   it should "mask everything when using the MaskedRequestLogFormatter" in {
     (new TestServlet() with MaskedRequestLogFormatter).formatRequestLog shouldBe
-      "request GET http://does.not.exist.dans.knaw.nl remote=**.**.**.78; params=[foo -> [bar]]; headers=[cookie -> [scentry.auth.default.user=****.****.****], HTTP_AUTHORIZATION -> [basic *****], foo -> [bar]]"
+      "request GET http://does.not.exist.dans.knaw.nl remote=12.**.**.**; params=[foo -> [bar]]; headers=[cookie -> [scentry.auth.default.user=****.****.****], HTTP_AUTHORIZATION -> [basic *****], foo -> [bar]]"
   }
 }

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/masked/MaskerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/masked/MaskerSpec.scala
@@ -120,7 +120,7 @@ class MaskerSpec extends FlatSpec with Matchers {
   }
 
   private case class TestCase(address: String, expected: String)
-  private val headCase::tailCases = Seq(
+  private val headCase::tailCases = List(
     TestCase("129.144.52.38", "129.**.**.**"), // IPv4
 
     // https://docs.oracle.com/javase/9/docs/api/java/net/Inet6Address.html

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/masked/MaskerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/masked/MaskerSpec.scala
@@ -91,35 +91,6 @@ class MaskerSpec extends FlatSpec with Matchers with TableDrivenPropertyChecks {
       "other-header" -> Seq("some value")
   }
 
-  "formatAuthenticationParameter" should "format authentication login parameter" in {
-    val headerKey = "login"
-    Masker.formatAuthenticationParameter(headerKey -> Seq("my-username")) shouldBe
-      headerKey -> Seq("*****")
-  }
-
-  it should "format authentication login parameter (after lowercasing)" in {
-    val headerKey = "login"
-    Masker.formatAuthenticationParameter(headerKey.toUpperCase -> Seq("my-username")) shouldBe
-      headerKey.toUpperCase -> Seq("*****")
-  }
-
-  it should "format authentication password parameter" in {
-    val headerKey = "password"
-    Masker.formatAuthenticationParameter(headerKey -> Seq("my-username")) shouldBe
-      headerKey -> Seq("*****")
-  }
-
-  it should "format authentication password parameter (after lowercasing)" in {
-    val headerKey = "password"
-    Masker.formatAuthenticationParameter(headerKey.toUpperCase -> Seq("my-username")) shouldBe
-      headerKey.toUpperCase -> Seq("*****")
-  }
-
-  it should "not format a header with another name than the given one" in {
-    Masker.formatAuthenticationParameter("other-header" -> Seq("some value")) shouldBe
-      "other-header" -> Seq("some value")
-  }
-
   "formatRemoteAddress" should "properly mask" in {
     val remoteAdressExamples = Table(("plainAddress", "maskedAddress"),
       ("129.144.52.38", "129.**.**.**"), // IPv4

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/masked/MaskerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/masked/MaskerSpec.scala
@@ -121,7 +121,7 @@ class MaskerSpec extends FlatSpec with Matchers with TableDrivenPropertyChecks {
   }
 
   "formatRemoteAddress" should "properly mask" in {
-    forEvery(Table(("plainAddress", "maskedAddress"),
+    val remoteAdressExamples = Table(("plainAddress", "maskedAddress"),
       ("129.144.52.38", "129.**.**.**"), // IPv4
 
       // https://docs.oracle.com/javase/9/docs/api/java/net/Inet6Address.html
@@ -175,7 +175,8 @@ class MaskerSpec extends FlatSpec with Matchers with TableDrivenPropertyChecks {
       ("::BA98::3210", "::BA98::**"),
       ("::BA98::3210::", "::BA98::**::"),
       ("::3210::", ":**:**:**"),
-    )) { (plainAddress: String, maskedAddress: String) =>
+    )
+    forEvery(remoteAdressExamples) { (plainAddress: String, maskedAddress: String) =>
       Masker.formatRemoteAddress(plainAddress) shouldBe maskedAddress
     }
   }

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/masked/MaskerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/masked/MaskerSpec.scala
@@ -120,7 +120,7 @@ class MaskerSpec extends FlatSpec with Matchers {
   }
 
   private case class TestCase(address: String, expected: String)
-  private val headCase::tailCases = List(
+  private val headCase :: tailCases = List(
     TestCase("129.144.52.38", "129.**.**.**"), // IPv4
 
     // https://docs.oracle.com/javase/9/docs/api/java/net/Inet6Address.html
@@ -157,13 +157,22 @@ class MaskerSpec extends FlatSpec with Matchers {
 
     // https://www.tutorialspoint.com/ipv6/ipv6_address_types.htm
     // composition of IPv6 Unicast:
-    // * 48 bits Global Routing Prefix
-    // * 16 bits Subnet ID
-    // * 64 bits Interface ID (possibly derived from a globally unique Mac address)
+    // * 48 bits (3 hex blocks) Global Routing Prefix
+    // * 16 bits (1 hex block) Subnet ID
+    // * 64 bits (2 hex blocks) Interface ID (possibly derived from a globally unique Mac address)
 
     // https://en.wikipedia.org/wiki/Reserved_IP_addresses
     // https://en.wikipedia.org/wiki/IP_address
     // TODO more special cases?
+
+    // self invented cases with more or less randomly suppressed zero blocks
+    TestCase("FEDC:BA98:7654:3210:FEDC::7654:3210", "FEDC:BA98:7654:3210:FEDC:**:**:**"),
+    TestCase("FEDC:BA98:7654:3210:FEDC:BA98::3210", "FEDC:BA98:7654:3210:FEDC:**:**:**"),
+    // the next ones are ambiguous: not clear which block is/are non-zero
+    TestCase("BA98::3210::", "BA98::**::"),
+    TestCase("::BA98::3210", "::BA98::**"),
+    TestCase("::BA98::3210::", "::BA98::**::"),
+    TestCase("::3210::", ":**:**:**"),
   )
 
   "formatRemoteAddress" should maskAddressOf(headCase) in { testAddress(headCase) }


### PR DESCRIPTION
fixes EASY-1992 mask IPv6 addresses

#### When applied it will
* mask IPv6 address and mixed IPv6/IPv4 addresses
* [ ] decide what to mask:
  the full subnet/interface ID's or just a least/most significant portion?
  ICT-Support ticket 2325
* [x] solving merge conflicts might have gone wrong
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* Upgrade a module like deposit-api to this version and deploy on `t`easy
* create request(s) the deposit-ui 
* examine the api log

#### related pull requests on github
has merge conflicts with #17 
