### PR TITLE
Split format from logging

### DIFF
--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
@@ -27,7 +27,7 @@ import org.scalatra.{ ActionResult, ScalatraBase }
  * used automatically (see the documentation of `logResponse` for an example).
  */
 trait AbstractServletLogger {
-  this: ScalatraBase =>
+  this: ScalatraBase with RequestLogFormatter with ResponseLogFormatter =>
 
   /**
    * This instance of the `AbstractServletLogger` in implicit scope.
@@ -39,10 +39,22 @@ trait AbstractServletLogger {
   }
 
   /**
+   * Output the given request `logLine` as desired.
+   * @param logLine the log line to be outputted
+   */
+  protected def logRequest(logLine: String): Unit
+
+  /**
+   * Output the given response `logLine` as desired.
+   * @param logLine the log line to be outputted
+   */
+  protected def logResponse(logLine: String): Unit
+
+  /**
    * Performs the side effect of the logging of the request.
    * This method is typically not called in user code, but rather in `ScalatraBase`'s `before` filter.
    */
-  def logRequest(): Unit
+  def logRequest(): Unit = logRequest(formatRequestLog)
 
   /**
    * Performs the side effect of the logging of the response, contained in the given `ActionResult`.
@@ -80,7 +92,10 @@ trait AbstractServletLogger {
    * @param actionResult the `ActionResult to be logged`
    * @return the original `ActionResult`
    */
-  def logResponse(actionResult: ActionResult): ActionResult
+  def logResponse(actionResult: ActionResult): ActionResult = {
+    logResponse(formatResponseLog(actionResult))
+    actionResult
+  }
 }
 
 /**
@@ -101,13 +116,10 @@ trait ServletLogger extends AbstractServletLogger {
   /**
    * @inheritdoc
    */
-  override def logRequest(): Unit = logger.info(formatRequestLog)
+  override protected def logRequest(logLine: String): Unit = logger.info(logLine)
 
   /**
    * @inheritdoc
    */
-  override def logResponse(actionResult: ActionResult): ActionResult = {
-    logger.info(formatResponseLog(actionResult))
-    actionResult
-  }
+  override protected def logResponse(logLine: String): Unit = logger.info(logLine)
 }

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/AbstractServletLoggerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/AbstractServletLoggerSpec.scala
@@ -19,7 +19,7 @@ import nl.knaw.dans.lib.logging.servlet.masked.MaskedRemoteAddress
 import org.scalatest.{ FlatSpec, Matchers }
 import org.scalatra.test.EmbeddedJettyContainer
 import org.scalatra.test.scalatest.ScalatraSuite
-import org.scalatra.{ ActionResult, Ok, ScalatraBase, ScalatraServlet }
+import org.scalatra.{ Ok, ScalatraBase, ScalatraServlet }
 
 class AbstractServletLoggerSpec extends FlatSpec with Matchers with EmbeddedJettyContainer with ScalatraSuite {
 
@@ -28,12 +28,13 @@ class AbstractServletLoggerSpec extends FlatSpec with Matchers with EmbeddedJett
     with RequestLogFormatter {
     this: ScalatraBase =>
 
-    override def logResponse(actionResult: ActionResult): ActionResult = {
-      stringBuilder append formatResponseLog(actionResult) append "\n"
-      actionResult
+    override protected def logRequest(logLine: String): Unit = {
+      stringBuilder append logLine append "\n"
     }
 
-    override def logRequest(): Unit = stringBuilder append formatRequestLog append "\n"
+    override protected def logResponse(logLine: String): Unit = {
+      stringBuilder append logLine append "\n"
+    }
   }
 
   private class TestServlet() extends ScalatraServlet with TestLoggers {


### PR DESCRIPTION
#### When applied it will
* move the 'infrastructure' of logging the request/response up to `AbstractServletLogger` and only leave the 'actual logging' to the implementor. Hence, `ServletLogger` only calls `logger.info(...)` and in the tests `AbstractServletLoggerSpec.TestLoggers` only has to deal with appending to `stringBuilder`.

@DANS-KNAW/easy for review

_Please note that this change seems quite unnecessary, as it doesn't change the public API for users of the logging package, nor does it add any functionality or change behaviour. However, this is all in preparation of a next step that will make the `.logResponse` call unnecessary._