### PR TITLE
No logResponse operator needed!

### DIFF
--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
@@ -27,7 +27,7 @@ import org.scalatra.{ ActionResult, ScalatraBase }
  * used automatically (see the documentation of `logResponse` for an example).
  */
 trait AbstractServletLogger {
-  this: ScalatraBase =>
+  this: ScalatraBase with RequestLogFormatter with ResponseLogFormatter =>
 
   /**
    * This instance of the `AbstractServletLogger` in implicit scope.
@@ -39,10 +39,22 @@ trait AbstractServletLogger {
   }
 
   /**
+   * Output the given request `logLine` as desired.
+   * @param logLine the log line to be outputted
+   */
+  protected def logRequest(logLine: String): Unit
+
+  /**
+   * Output the given response `logLine` as desired.
+   * @param logLine the log line to be outputted
+   */
+  protected def logResponse(logLine: String): Unit
+
+  /**
    * Performs the side effect of the logging of the request.
    * This method is typically not called in user code, but rather in `ScalatraBase`'s `before` filter.
    */
-  def logRequest(): Unit
+  def logRequest(): Unit = logRequest(formatRequestLog)
 
   /**
    * Performs the side effect of the logging of the response, contained in the given `ActionResult`.
@@ -80,7 +92,10 @@ trait AbstractServletLogger {
    * @param actionResult the `ActionResult to be logged`
    * @return the original `ActionResult`
    */
-  def logResponse(actionResult: ActionResult): ActionResult
+  def logResponse(actionResult: ActionResult): ActionResult = {
+    logResponse(formatResponseLog(actionResult))
+    actionResult
+  }
 }
 
 /**
@@ -101,13 +116,10 @@ trait ServletLogger extends AbstractServletLogger {
   /**
    * @inheritdoc
    */
-  override def logRequest(): Unit = logger.info(formatRequestLog)
+  override protected def logRequest(logLine: String): Unit = logger.info(logLine)
 
   /**
    * @inheritdoc
    */
-  override def logResponse(actionResult: ActionResult): ActionResult = {
-    logger.info(formatResponseLog(actionResult))
-    actionResult
-  }
+  override protected def logResponse(logLine: String): Unit = logger.info(logLine)
 }

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
@@ -23,8 +23,7 @@ import org.scalatra.{ ActionResult, ScalatraBase }
  * and `logResponse`.
  * Furthermore it adds a call to `logRequest` to the 'before filters' of `ScalatraBase`,
  * such that this method is called automatically on every request that comes in.
- * Finally it provides a 'self-pointer' in implicit scope, such that `LogResponseSyntax` can be
- * used automatically (see the documentation of `logResponse` for an example).
+ * Also it extends the Scalatra's `renderResponse` method with a call to `logResponse`.
  */
 trait AbstractServletLogger extends ScalatraBase {
   this: RequestLogFormatter with ResponseLogFormatter =>
@@ -32,6 +31,7 @@ trait AbstractServletLogger extends ScalatraBase {
   /**
    * This instance of the `AbstractServletLogger` in implicit scope.
    */
+  @deprecated("not necessary anymore, will be deleted in future version.", "1.5.1")
   implicit val responseLogger: AbstractServletLogger = this
 
   before() {
@@ -41,20 +41,24 @@ trait AbstractServletLogger extends ScalatraBase {
   override protected def renderResponse(actionResult: Any): Unit = {
     super.renderResponse(actionResult)
 
-    actionResult match {
-      case ar: ActionResult => logResponse(ar)
-      case _ => logResponse(ActionResult(response.status, actionResult, Map.empty))
+    logResponse {
+      actionResult match {
+        case ar: ActionResult => ar
+        case _ => ActionResult(response.status, actionResult, Map.empty)
+      }
     }
   }
 
   /**
    * Output the given request `logLine` as desired.
+   *
    * @param logLine the log line to be outputted
    */
   protected def logRequest(logLine: String): Unit
 
   /**
    * Output the given response `logLine` as desired.
+   *
    * @param logLine the log line to be outputted
    */
   protected def logResponse(logLine: String): Unit
@@ -67,40 +71,11 @@ trait AbstractServletLogger extends ScalatraBase {
 
   /**
    * Performs the side effect of the logging of the response, contained in the given `ActionResult`.
-   * This method is either called directly or via the extension method provided by
-   * `LogResponseSyntax`.
-   * In the examples below the two syntaxes are shown. Please note that the only difference is
-   * `logResponse { Ok() }` vs. `Ok().logResponse`.
    *
-   * @example
-   * {{{
-   *   import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-   *   import nl.knaw.dans.lib.logging.servlet._
-   *   import org.scalatra.{ Ok, ScalatraServlet }
-   *
-   *   class ExampleServlet extends ScalatraServlet with ServletLogger with DebugEnhancedLogging {
-   *     get("/") {
-   *       logResponse {
-   *         Ok("All is well")
-   *       }
-   *     }
-   *   }
-   * }}}
-   * @example
-   * {{{
-   *   import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-   *   import nl.knaw.dans.lib.logging.servlet._
-   *   import org.scalatra.{ Ok, ScalatraServlet }
-   *
-   *   class ExampleServlet extends ScalatraServlet with ServletLogger with DebugEnhancedLogging {
-   *     get("/") {
-   *       Ok("All is well").logResponse
-   *     }
-   *   }
-   * }}}
    * @param actionResult the `ActionResult to be logged`
    * @return the original `ActionResult`
    */
+  // TODO remove return type in future version, once `.logResponse` syntax is deleted
   def logResponse(actionResult: ActionResult): ActionResult = {
     logResponse(formatResponseLog(actionResult))
     actionResult

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
@@ -26,8 +26,8 @@ import org.scalatra.{ ActionResult, ScalatraBase }
  * Finally it provides a 'self-pointer' in implicit scope, such that `LogResponseSyntax` can be
  * used automatically (see the documentation of `logResponse` for an example).
  */
-trait AbstractServletLogger {
-  this: ScalatraBase with RequestLogFormatter with ResponseLogFormatter =>
+trait AbstractServletLogger extends ScalatraBase {
+  this: RequestLogFormatter with ResponseLogFormatter =>
 
   /**
    * This instance of the `AbstractServletLogger` in implicit scope.
@@ -36,6 +36,15 @@ trait AbstractServletLogger {
 
   before() {
     logRequest()
+  }
+
+  override protected def renderResponse(actionResult: Any): Unit = {
+    super.renderResponse(actionResult)
+
+    actionResult match {
+      case ar: ActionResult => logResponse(ar)
+      case _ => logResponse(ActionResult(response.status, actionResult, Map.empty))
+    }
   }
 
   /**

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/body/LogResponseBody.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/body/LogResponseBody.scala
@@ -29,6 +29,7 @@ private[servlet] trait LogResponseBody extends ResponseLogFormatter {
   override protected def formatResponseLog(actionResult: ActionResult): String = {
     val formattedBody = formatResponseBody(actionResult)
       .withFilter(Unit !=)
+      .withFilter(() !=)
       .map(String.valueOf)
       .map {
         case b if b.isBlank => "; body=[]"

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
@@ -149,35 +149,35 @@ package object servlet {
       }.mkString("[", ", ", "]")
     }
   }
-
-  /**
-   * Convenience syntax for logging a response.
-   *
-   * @param actionResult the `ActionResult to be logged`
-   */
-  implicit class LogResponseSyntax(val actionResult: ActionResult) extends AnyVal {
-    /**
-     * Performs the side effect of the logging of the response, contained in the given `ActionResult`.\
-     *
-     * @example
-     * {{{
-     *   import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-     *   import nl.knaw.dans.lib.logging.servlet._
-     *   import org.scalatra.{ Ok, ScalatraServlet }
-     *
-     *   class ExampleServlet extends ScalatraServlet with ServletLogger with DebugEnhancedLogging {
-     *     get("/") {
-     *       Ok("All is well").logResponse
-     *     }
-     *   }
-     * }}}
-     * @param responseLogger the logger with which to format/output the response
-     * @return the original `ActionResult`
-     */
-    def logResponse(implicit responseLogger: AbstractServletLogger): ActionResult = {
-      responseLogger.logResponse(actionResult)
-    }
-  }
+//
+//  /**
+//   * Convenience syntax for logging a response.
+//   *
+//   * @param actionResult the `ActionResult to be logged`
+//   */
+//  implicit class LogResponseSyntax(val actionResult: ActionResult) extends AnyVal {
+//    /**
+//     * Performs the side effect of the logging of the response, contained in the given `ActionResult`.\
+//     *
+//     * @example
+//     * {{{
+//     *   import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+//     *   import nl.knaw.dans.lib.logging.servlet._
+//     *   import org.scalatra.{ Ok, ScalatraServlet }
+//     *
+//     *   class ExampleServlet extends ScalatraServlet with ServletLogger with DebugEnhancedLogging {
+//     *     get("/") {
+//     *       Ok("All is well").logResponse
+//     *     }
+//     *   }
+//     * }}}
+//     * @param responseLogger the logger with which to format/output the response
+//     * @return the original `ActionResult`
+//     */
+//    def logResponse(implicit responseLogger: AbstractServletLogger): ActionResult = {
+//      responseLogger.logResponse(actionResult)
+//    }
+//  }
 
   trait PlainLogFormatter extends RequestLogFormatter with ResponseLogFormatter {
     this: ScalatraBase =>

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.lib.logging
 
-import org.scalatra.{ ActionResult, ScalatraBase }
+import org.scalatra.ScalatraBase
 
 /**
  * Package for logging servlet requests and responses in a standardized format.

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.lib.logging
 
-import org.scalatra.ScalatraBase
+import org.scalatra.{ ActionResult, ScalatraBase }
 
 /**
  * Package for logging servlet requests and responses in a standardized format.
@@ -39,7 +39,7 @@ import org.scalatra.ScalatraBase
  * In the example below we use `DebugEnhancedLogging` for the latter. The `PlainLogFormatter`
  * and `MaskedLogFormatter` both implement the two LogFormatters. The latter masks privacy sensitive
  * values like user names, passwords and remote addresses.
- * 
+ *
  * To also log the body of a response, either add `LogResponseBodyAlways` or `LogResponseBodyOnError`.
  *
  * When you want to mask less, for example to debug tests, add individual
@@ -58,7 +58,7 @@ import org.scalatra.ScalatraBase
  *      with DebugEnhancedLogging {
  *
  *      get("/") {
- *        Ok("All is well").logResponse
+ *        Ok("All is well")
  *      }
  *    }
  *
@@ -69,7 +69,7 @@ import org.scalatra.ScalatraBase
  *      with DebugEnhancedLogging {
  *
  *      get("/") {
- *        Ok("All is well").logResponse
+ *        Ok("All is well")
  *      }
  *    }
  *
@@ -83,7 +83,7 @@ import org.scalatra.ScalatraBase
  *      with DebugEnhancedLogging {
  *
  *      get("/") {
- *        Ok("All is well").logResponse
+ *        Ok("All is well")
  *      }
  *    }
  * }}}
@@ -121,7 +121,7 @@ import org.scalatra.ScalatraBase
  *      with DebugEnhancedLogging {
  *
  *      get("/") {
- *        Ok("All is well").logResponse
+ *        Ok("All is well")
  *      }
  *    }
  * }}}
@@ -152,35 +152,39 @@ package object servlet {
       }.mkString("[", ", ", "]")
     }
   }
-//
-//  /**
-//   * Convenience syntax for logging a response.
-//   *
-//   * @param actionResult the `ActionResult to be logged`
-//   */
-//  implicit class LogResponseSyntax(val actionResult: ActionResult) extends AnyVal {
-//    /**
-//     * Performs the side effect of the logging of the response, contained in the given `ActionResult`.\
-//     *
-//     * @example
-//     * {{{
-//     *   import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-//     *   import nl.knaw.dans.lib.logging.servlet._
-//     *   import org.scalatra.{ Ok, ScalatraServlet }
-//     *
-//     *   class ExampleServlet extends ScalatraServlet with ServletLogger with DebugEnhancedLogging {
-//     *     get("/") {
-//     *       Ok("All is well").logResponse
-//     *     }
-//     *   }
-//     * }}}
-//     * @param responseLogger the logger with which to format/output the response
-//     * @return the original `ActionResult`
-//     */
-//    def logResponse(implicit responseLogger: AbstractServletLogger): ActionResult = {
-//      responseLogger.logResponse(actionResult)
-//    }
-//  }
+
+  /**
+   * Convenience syntax for logging a response.
+   *
+   * @param actionResult the `ActionResult to be logged`
+   */
+  @deprecated("Using .logResponse is no longer necessary. " +
+    "Continued usage will result in the response being logged twice.", "1.5.1")
+  implicit class LogResponseSyntax(val actionResult: ActionResult) extends AnyVal {
+    /**
+     * Performs the side effect of the logging of the response, contained in the given `ActionResult`.\
+     *
+     * @example
+     * {{{
+     *   import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+     *   import nl.knaw.dans.lib.logging.servlet._
+     *   import org.scalatra.{ Ok, ScalatraServlet }
+     *
+     *   class ExampleServlet extends ScalatraServlet with ServletLogger with DebugEnhancedLogging {
+     *     get("/") {
+     *       Ok("All is well").logResponse
+     *     }
+     *   }
+     * }}}
+     * @param responseLogger the logger with which to format/output the response
+     * @return the original `ActionResult`
+     */
+    @deprecated("Using .logResponse is no longer necessary. " +
+      "Continued usage will result in the response being logged twice.", "1.5.1")
+    def logResponse(implicit responseLogger: AbstractServletLogger): ActionResult = {
+      responseLogger.logResponse(actionResult)
+    }
+  }
 
   trait PlainLogFormatter extends RequestLogFormatter with ResponseLogFormatter {
     this: ScalatraBase =>

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/AbstractServletLoggerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/AbstractServletLoggerSpec.scala
@@ -19,7 +19,7 @@ import nl.knaw.dans.lib.logging.servlet.masked.MaskedRemoteAddress
 import org.scalatest.{ FlatSpec, Matchers }
 import org.scalatra.test.EmbeddedJettyContainer
 import org.scalatra.test.scalatest.ScalatraSuite
-import org.scalatra.{ ActionResult, Ok, ScalatraBase, ScalatraServlet }
+import org.scalatra.{ Ok, ScalatraBase, ScalatraServlet }
 
 class AbstractServletLoggerSpec extends FlatSpec with Matchers with EmbeddedJettyContainer with ScalatraSuite {
 
@@ -28,12 +28,13 @@ class AbstractServletLoggerSpec extends FlatSpec with Matchers with EmbeddedJett
     with RequestLogFormatter {
     this: ScalatraBase =>
 
-    override def logResponse(actionResult: ActionResult): ActionResult = {
-      stringBuilder append formatResponseLog(actionResult) append "\n"
-      actionResult
+    override protected def logRequest(logLine: String): Unit = {
+      stringBuilder append logLine append "\n"
     }
 
-    override def logRequest(): Unit = stringBuilder append formatRequestLog append "\n"
+    override protected def logResponse(logLine: String): Unit = {
+      stringBuilder append logLine append "\n"
+    }
   }
 
   private class TestServlet() extends ScalatraServlet with TestLoggers {

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/AbstractServletLoggerSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/AbstractServletLoggerSpec.scala
@@ -41,7 +41,7 @@ class AbstractServletLoggerSpec extends FlatSpec with Matchers with EmbeddedJett
 
     get("/") {
       contentType = "text/plain"
-      Ok("How y'all doin'?").logResponse
+      Ok("How y'all doin'?")
     }
   }
 

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/LogWithBodyOnErrorServlet.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/LogWithBodyOnErrorServlet.scala
@@ -27,6 +27,6 @@ class LogWithBodyOnErrorServlet extends ScalatraServlet
   with DebugEnhancedLogging {
 
   get("/") {
-    NotAcceptable("foobar").logResponse
+    NotAcceptable("foobar")
   }
 }

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/MaskSpecificCookieServlet.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/MaskSpecificCookieServlet.scala
@@ -50,6 +50,6 @@ class MaskSpecificCookieServlet extends ScalatraServlet
   with DebugEnhancedLogging {
 
   get("/") {
-    Ok("foobar").logResponse
+    Ok("foobar")
   }
 }

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/MaskedLogServlet.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/MaskedLogServlet.scala
@@ -25,6 +25,6 @@ class MaskedLogServlet extends ScalatraServlet
   with DebugEnhancedLogging {
 
   get("/") {
-    Ok("foobar").logResponse
+    Ok("foobar")
   }
 }

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/PartiallyMaskedLogServlet.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/PartiallyMaskedLogServlet.scala
@@ -28,6 +28,6 @@ class PartiallyMaskedLogServlet extends ScalatraServlet
   with DebugEnhancedLogging {
 
   get("/") {
-    Ok("foobar").logResponse
+    Ok("foobar")
   }
 }

--- a/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/PlainLogServlet.scala
+++ b/src/test/scala/nl/knaw/dans/lib/logging/servlet/examples/PlainLogServlet.scala
@@ -25,6 +25,6 @@ class PlainLogServlet extends ScalatraServlet
   with DebugEnhancedLogging {
 
   get("/") {
-    Ok("foobar").logResponse
+    Ok("foobar")
   }
 }


### PR DESCRIPTION
Turns out, we don't need the `.logResponse` operator. I made it deprecated by now, but continued usage will result in logging the response twice.

Instead of manually calling `.logResponse`, we override `renderResponse` in `AbstractServletLogger ` and handle the response logging there.

Also, I adjusted the documentation and examples that mentioned the `.logResponse` operator.

By changing the way of logging, EASY-1993 is now fixed as well.

@DANS-KNAW/easy for review