### PR TITLE
Some maintenance on code base

### DIFF
--- a/src/main/scala/nl/knaw/dans/lib/encode/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/encode/package.scala
@@ -15,8 +15,11 @@
  */
 package nl.knaw.dans.lib
 
-import com.google.common.net.PercentEscaper
 import java.nio.file.Path
+
+import com.google.common.escape.Escaper
+import com.google.common.net.PercentEscaper
+
 import scala.collection.JavaConverters._
 
 package object encode {
@@ -40,7 +43,7 @@ package object encode {
      *  }}}
      * @return an escaped path
      */
-    def escapePath(implicit escaper: PercentEscaper = bagStorePercentEscaper): String = {
+    def escapePath(implicit escaper: Escaper = bagStorePercentEscaper): String = {
       path.asScala.map(_.toString.escapeString).mkString("/")
     }
   }
@@ -59,8 +62,8 @@ package object encode {
      *  }}}
      * @return an escaped string
      */
-    def escapeString(implicit percentEscaper: PercentEscaper = bagStorePercentEscaper): String = {
-      percentEscaper.escape(s)
+    def escapeString(implicit escaper: Escaper = bagStorePercentEscaper): String = {
+      escaper.escape(s)
     }
   }
 }

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/ServletLogger.scala
@@ -28,12 +28,6 @@ import org.scalatra.{ ActionResult, ScalatraBase }
 trait AbstractServletLogger extends ScalatraBase {
   this: RequestLogFormatter with ResponseLogFormatter =>
 
-  /**
-   * This instance of the `AbstractServletLogger` in implicit scope.
-   */
-  @deprecated("not necessary anymore, will be deleted in future version.", "1.5.1")
-  implicit val responseLogger: AbstractServletLogger = this
-
   before() {
     logRequest()
   }
@@ -73,13 +67,8 @@ trait AbstractServletLogger extends ScalatraBase {
    * Performs the side effect of the logging of the response, contained in the given `ActionResult`.
    *
    * @param actionResult the `ActionResult to be logged`
-   * @return the original `ActionResult`
    */
-  // TODO remove return type in future version, once `.logResponse` syntax is deleted
-  def logResponse(actionResult: ActionResult): ActionResult = {
-    logResponse(formatResponseLog(actionResult))
-    actionResult
-  }
+  def logResponse(actionResult: ActionResult): Unit = logResponse(formatResponseLog(actionResult))
 }
 
 /**

--- a/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/logging/servlet/package.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.lib.logging
 
-import org.scalatra.{ ActionResult, ScalatraBase }
+import org.scalatra.ScalatraBase
 
 /**
  * Package for logging servlet requests and responses in a standardized format.
@@ -150,39 +150,6 @@ package object servlet {
         case (k, v: Map[_, _]) => k -> v.makeString
         case kv => kv
       }.mkString("[", ", ", "]")
-    }
-  }
-
-  /**
-   * Convenience syntax for logging a response.
-   *
-   * @param actionResult the `ActionResult to be logged`
-   */
-  @deprecated("Using .logResponse is no longer necessary. " +
-    "Continued usage will result in the response being logged twice.", "1.5.1")
-  implicit class LogResponseSyntax(val actionResult: ActionResult) extends AnyVal {
-    /**
-     * Performs the side effect of the logging of the response, contained in the given `ActionResult`.\
-     *
-     * @example
-     * {{{
-     *   import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-     *   import nl.knaw.dans.lib.logging.servlet._
-     *   import org.scalatra.{ Ok, ScalatraServlet }
-     *
-     *   class ExampleServlet extends ScalatraServlet with ServletLogger with DebugEnhancedLogging {
-     *     get("/") {
-     *       Ok("All is well").logResponse
-     *     }
-     *   }
-     * }}}
-     * @param responseLogger the logger with which to format/output the response
-     * @return the original `ActionResult`
-     */
-    @deprecated("Using .logResponse is no longer necessary. " +
-      "Continued usage will result in the response being logged twice.", "1.5.1")
-    def logResponse(implicit responseLogger: AbstractServletLogger): ActionResult = {
-      responseLogger.logResponse(actionResult)
     }
   }
 


### PR DESCRIPTION
#### When applied it will
* remove deprecated code from old `.logResponse` implementation
* replace `PercentEncoder` with general `Escaper` in `escapePath` and `escapeString` methods

@DANS-KNAW/easy for review