### PR TITLE
EASY-2348: stricter UUID parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,10 @@
             <artifactId>scalamock_2.12</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.scalacheck</groupId>
+            <artifactId>scalacheck_2.12</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.scalatra</groupId>
             <artifactId>scalatra-scalatest_2.12</artifactId>
         </dependency>

--- a/src/main/scala/nl/knaw/dans/lib/string/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/string/package.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.lib
 
+import java.util.UUID
+
 package object string {
 
   implicit class StringExtensions(val s: String) extends AnyVal {
@@ -51,5 +53,15 @@ package object string {
      *         the input otherwise
      */
     def emptyIfBlank: String = s.toOption.getOrElse("")
+
+    def toUUID: Either[UUIDError, UUID] = {
+      val uuidRegex = "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+      if (s matches uuidRegex)
+        Right(UUID.fromString(s))
+      else
+        Left(UUIDError(s))
+    }
   }
+  
+  case class UUIDError(s: String) extends Exception(s"String '$s' is not a UUID")
 }

--- a/src/main/scala/nl/knaw/dans/lib/string/package.scala
+++ b/src/main/scala/nl/knaw/dans/lib/string/package.scala
@@ -54,6 +54,12 @@ package object string {
      */
     def emptyIfBlank: String = s.toOption.getOrElse("")
 
+    /**
+     * Parses the `String` into a `UUID` if it is well-formed, meaning it conforms to the regex
+     * `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`.
+     * 
+     * @return a `UUID` if it is well-formed; an error otherwise.
+     */
     def toUUID: Either[UUIDError, UUID] = {
       val uuidRegex = "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
       if (s matches uuidRegex)

--- a/src/test/scala/nl/knaw/dans/lib/string/StringExtensionsSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/string/StringExtensionsSpec.scala
@@ -15,9 +15,11 @@
  */
 package nl.knaw.dans.lib.string
 
-import org.scalatest.{ FlatSpec, Matchers, OptionValues }
+import java.util.UUID
 
-class StringExtensionsSpec extends FlatSpec with Matchers with OptionValues {
+import org.scalatest.{ EitherValues, FlatSpec, Matchers, OptionValues }
+
+class StringExtensionsSpec extends FlatSpec with Matchers with OptionValues with EitherValues {
 
   "isBlank" should "return true when given an empty String" in {
     "".isBlank shouldBe true
@@ -92,5 +94,29 @@ class StringExtensionsSpec extends FlatSpec with Matchers with OptionValues {
   it should "return the original String when the input contains both blank and non-blank characters" in {
     val input = "ab c "
     input.emptyIfBlank shouldBe input
+  }
+
+  "toUUID" should "return a UUID on a valid input" in {
+    val input = "12341234-1234-1234-1234-123412341234"
+    val expectedOutput = UUID.fromString(input)
+    
+    input.toUUID.right.value shouldBe expectedOutput
+  }
+  
+  it should "return an error on an invalid input" in {
+    val input = "xyz"
+    
+    input.toUUID.left.value shouldBe UUIDError(input)
+  }
+
+  it should "return an error on an input that is valid according to Java's UUID parser, but does not conform to the pattern of a UUID" in {
+    val input = "1-2-3-4-5"
+    val javaOutput = UUID.fromString(input)
+
+    // this is what the Java parser does, but this is not what we want!
+    javaOutput.toString shouldBe "00000001-0002-0003-0004-000000000005"
+    
+    // this is what we would expect for an not-wellformed UUID
+    input.toUUID.left.value shouldBe UUIDError(input)
   }
 }

--- a/src/test/scala/nl/knaw/dans/lib/string/UUIDPropSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/string/UUIDPropSpec.scala
@@ -1,0 +1,16 @@
+package nl.knaw.dans.lib.string
+
+import org.scalacheck.Gen
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{ EitherValues, Matchers, PropSpec }
+
+class UUIDPropSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers with EitherValues {
+
+  property("a valid UUID, converted to a String should be parsed back to the same UUID") {
+    forAll(Gen.uuid)(uuid => {
+      val uuidString = uuid.toString
+
+      uuidString.toUUID.right.value shouldBe uuid
+    })
+  }
+}

--- a/src/test/scala/nl/knaw/dans/lib/string/UUIDPropSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/string/UUIDPropSpec.scala
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package nl.knaw.dans.lib.string
 
 import org.scalacheck.Gen


### PR DESCRIPTION
preparation for EASY-2348

#### When applied it will
* make a stricter UUID parser available that first checks whether the input `String` is well-formed

It is recommended that after this feature is released in the next version of the library, all usage of `UUID.fromString(s)` in DANS/Scala modules is replaced by `s.toUUID`.

@DANS-KNAW/easy for review