### PR TITLE
EASY-2474 Convert documentation to mkdocs

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+GH_ORG=DANS-KNAW
+
+set -e
+
+# Relies on Travis checking out repo to a dir with the repo's name.
+GH_REPO=$(basename $TRAVIS_BUILD_DIR)
+REMOTE="https://${GH_TOKEN}@github.com/${GH_ORG}/${GH_REPO}"
+git remote set-url origin ${REMOTE}
+
+echo "START installing required Python packages..."
+pip3 install mkdocs
+pip3 install pygments
+pip3 install pymdown-extensions
+pip3 install pyyaml
+pip3 install mkdocs-markdownextradata-plugin
+echo "DONE installing required Python packages."
+
+echo "START installing DANS mkdocs theme..."
+git clone https://github.com/Dans-labs/mkdocs-dans $HOME/mkdocs-dans
+pushd $HOME/mkdocs-dans
+git pull
+python3 build.py pack
+popd
+echo "DONE installing DANS mkdocs theme."
+
+echo "START deploying docs to GitHub pages..."
+mkdocs gh-deploy --force
+echo "DONE deploying docs to GitHub pages."

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,16 @@
-language: java
-jdk: openjdk8
-cache:
-  directories:
-    - "$HOME/.m2/repository"
+matrix:
+  include:
+    - language: java
+      jdk: openjdk8
+      cache:
+        directories:
+          - "$HOME/.m2/repository"
+    - language: python
+      if: branch = master AND NOT type = pull_request
+      python: 3.7.1
+      cache:
+        directories:
+          - "$HOME/.cache"
+          - "$HOME/virtualenv"
+      script:
+        - "./.travis.sh"

--- a/README.md
+++ b/README.md
@@ -1,45 +1,10 @@
 dans-scala-lib
 ==============
+[![Build Status](https://travis-ci.org/DANS-KNAW/dans-scala-lib.png?branch=master)](https://travis-ci.org/DANS-KNAW/dans-scala-lib)
 
 Library with generic extensions for Scala-based DANS modules
 
+Welcome
+-------
 
-DESCRIPTION
------------
-
-The DANS development team uses Scala as its main programming language. 
-We aim to maintain a commons style of coding. Some of the coding idioms
-recur often. In cases where these patterns are not captured already by
-a good, third party, open source library we put them in `dans-scala-lib`.
-
-The objects, classes and functions in this library are intended to be 
-useful for all of our projects. The library only declares a minimal number
-of dependencies.
-
-
-INSTALLATION
-------------
-
-To use this libary in a Maven-based project:
-
-1. Include in your `pom.xml` a declaration for the DANS maven repository:
-
-        <repositories>
-            <!-- possibly other repository declartions here ... -->
-            <repository>
-                <id>DANS</id>
-                <releases>
-                    <enabled>true</enabled>
-                </releases>
-                <url>https://maven.dans.knaw.nl/releases/</url>
-            </repository>
-        </repositories>
-
-2. Include a dependency on this library. The version should of course be
-   set to the latest version (or left out, if it is managed by an ancestor `pom.xml`).
-
-        <dependency>
-            <groupId>nl.knaw.dans.lib</groupId>
-            <artifactId>dans-scala-lib</artifactId>
-            <version>1.0</version>
-        </dependency>
+Welcome to the `dans-scala-lib` project. See the [GitHub pages](https://dans-knaw.github.io/dans-scala-lib/) for the manual.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,46 @@
+MANUAL
+======
+[![Build Status](https://travis-ci.org/DANS-KNAW/dans-scala-lib.png?branch=master)](https://travis-ci.org/DANS-KNAW/dans-scala-lib)
+
+Library with generic extensions for Scala-based DANS modules
+
+
+DESCRIPTION
+-----------
+
+The DANS development team uses Scala as its main programming language. 
+We aim to maintain a commons style of coding. Some of the coding idioms
+recur often. In cases where these patterns are not captured already by
+a good, third party, open source library we put them in `dans-scala-lib`.
+
+The objects, classes and functions in this library are intended to be 
+useful for all of our projects. The library only declares a minimal number
+of dependencies.
+
+
+INSTALLATION
+------------
+
+To use this libary in a Maven-based project:
+
+1. Include in your `pom.xml` a declaration for the DANS maven repository:
+
+        <repositories>
+            <!-- possibly other repository declartions here ... -->
+            <repository>
+                <id>DANS</id>
+                <releases>
+                    <enabled>true</enabled>
+                </releases>
+                <url>https://maven.dans.knaw.nl/releases/</url>
+            </repository>
+        </repositories>
+
+2. Include a dependency on this library. The version should of course be
+   set to the latest version (or left out, if it is managed by an ancestor `pom.xml`).
+
+        <dependency>
+            <groupId>nl.knaw.dans.lib</groupId>
+            <artifactId>dans-scala-lib</artifactId>
+            <version>1.0</version>
+        </dependency>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+site_name: dans-scala-lib
+theme:
+  name: dans
+  disclaimer: false
+
+repo_name: DANS-KNAW/dans-scala-lib
+repo_url: https://github.com/DANS-KNAW/dans-scala-lib
+
+nav:
+  - Manual: index.md
+
+plugins:
+  - markdownextradata
+  - search
+
+markdown_extensions:
+  - attr_list
+  #- legacy_attr
+  - admonition
+  - codehilite:
+      guess_lang: false
+  - def_list
+  - footnotes
+  - meta
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.caret
+  - pymdownx.critic
+  - pymdownx.details
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.magiclink:
+      repo_url_shorthand: true
+      user: Dans-labs
+      repo: mkdocs-dans
+  - pymdownx.mark
+  - pymdownx.smartsymbols
+  - pymdownx.superfences
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde


### PR DESCRIPTION
fixes EASY-2474

#### When applied it will
* convert the project documentation to mkdocs format

#### Where should the reviewer @DANS-KNAW/easy start?
check out the project, run `mkdocs serve`

#### How should this be manually tested?
https://dans-labs.github.io/mkdocs-dans/