### PR TITLE
DD-249 Add tests for taskqueue classes

### DIFF
--- a/src/test/scala/nl/knaw/dans/lib/taskqueue/ActiveTaskQueueSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/taskqueue/ActiveTaskQueueSpec.scala
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.taskqueue
+
+import org.scalatest.OneInstancePerTest
+import org.scalatest.concurrent.{ Eventually, IntegrationPatience }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ActiveTaskQueueSpec extends AnyFlatSpec with Matchers with OneInstancePerTest with Eventually with IntegrationPatience {
+
+  "start" should "process previously queued tasks" in {
+    val taskQueue = new ActiveTaskQueue[Any]()
+    val triggeredTasks = List(
+      TriggerTask(),
+      TriggerTask(),
+      TriggerTask(),
+    )
+
+    triggeredTasks.foreach(taskQueue.add)
+    taskQueue.start()
+
+    eventually {
+      triggeredTasks(0).triggered shouldBe true
+      triggeredTasks(1).triggered shouldBe true
+      triggeredTasks(2).triggered shouldBe true
+    }
+
+    taskQueue.stop()
+  }
+
+  it should "process other tasks if one task fails" in {
+    val taskQueue = new ActiveTaskQueue[Any]()
+    val triggeredTasks = List(
+      TriggerTask(),
+      TriggerTask(shouldFail = true),
+      TriggerTask(),
+    )
+
+    triggeredTasks.foreach(taskQueue.add)
+    taskQueue.start()
+
+    eventually {
+      triggeredTasks(0).triggered shouldBe true
+      triggeredTasks(2).triggered shouldBe true
+    }
+
+    taskQueue.stop()
+  }
+}

--- a/src/test/scala/nl/knaw/dans/lib/taskqueue/ActiveTaskQueueSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/taskqueue/ActiveTaskQueueSpec.scala
@@ -16,11 +16,10 @@
 package nl.knaw.dans.lib.taskqueue
 
 import better.files.File
-import org.scalatest.{ OneInstancePerTest, time }
+import org.scalatest.OneInstancePerTest
 import org.scalatest.concurrent.{ Eventually, IntegrationPatience }
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.time.{ Seconds, Span }
 
 import scala.util.Try
 

--- a/src/test/scala/nl/knaw/dans/lib/taskqueue/FileTriggerTask.scala
+++ b/src/test/scala/nl/knaw/dans/lib/taskqueue/FileTriggerTask.scala
@@ -15,22 +15,18 @@
  */
 package nl.knaw.dans.lib.taskqueue
 
+import better.files.File
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
 import scala.util.Try
 
-/**
- *
- * @param shouldFail if this is set to true the task will throw an exception in the run method
- */
-case class TriggerTask(shouldFail: Boolean = false) extends Task[Any] with DebugEnhancedLogging {
+case class FileTriggerTask(target: File = null, shouldFail: Boolean = false) extends Task[File] with DebugEnhancedLogging {
   var triggered = false
 
   override def run(): Try[Unit] = Try {
-    trace(())
-    if (shouldFail) throw new Exception("Task failed")
     triggered = true
+    if (shouldFail) throw new Exception("Task failed")
   }
 
-  override def getTarget: Any = {}
+  override def getTarget: File = target
 }

--- a/src/test/scala/nl/knaw/dans/lib/taskqueue/InboxSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/taskqueue/InboxSpec.scala
@@ -1,0 +1,206 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.taskqueue
+
+import better.files.File
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.{ Eventually, IntegrationPatience }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.mutable.ListBuffer
+import scala.util.Success
+
+class InboxSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach with Eventually with IntegrationPatience with MockFactory {
+
+  val testDir: File = File.currentWorkingDirectory / "target" / "test" / getClass.getSimpleName
+  val inboxDir: File = testDir / "inbox"
+
+  // Inbox implementation for testing purposes which creates tasks for .txt files and failing tasks for .jpg files
+  case class TestInbox() extends AbstractInbox[File](inboxDir) {
+    val createdTasks: ListBuffer[Task[File]] = ListBuffer[Task[File]]() // keep track of tasks created
+
+    override def createTask(f: File): Option[Task[File]] = f.extension match {
+      case Some(".txt") => {
+        // mocking a Task instance to test sorting tasks more easily
+        val fileTask = stub[Task[File]]
+        (fileTask.getTarget _).when().returns(f)
+        (fileTask.run _).when().returns(Success(()))
+
+        createdTasks += fileTask
+        Some(fileTask)
+      }
+
+      case Some(".jpg") => {
+        val fileTask = stub[Task[File]]
+        (fileTask.getTarget _).when().returns(f)
+        (fileTask.run _).when().throws(new Exception("Task failed"))
+
+        createdTasks += fileTask
+        Some(fileTask)
+      }
+
+      case _ => None
+    }
+  }
+
+  override def beforeEach(): Unit = {
+    inboxDir.createDirectories()
+    inboxDir.clear()
+  }
+
+  "start" should "process files already in inbox" in {
+    val file1: File = (inboxDir / "file1.txt").createFile()
+    val file2: File = (inboxDir / "file2.txt").createFile()
+
+    val testInbox = TestInbox()
+    val inboxWatcher = new InboxWatcher[File](testInbox)
+
+    inboxWatcher.start()
+
+    eventually {
+      testInbox.createdTasks.size shouldBe 2
+
+      // verify the tasks target the correct files
+      testInbox.createdTasks.exists(_.getTarget == file1) shouldBe true
+      testInbox.createdTasks.exists(_.getTarget == file2) shouldBe true
+
+      // verify all tasks' run method has been called
+      (testInbox.createdTasks(0).run _).verify()
+      (testInbox.createdTasks(1).run _).verify()
+    }
+
+    inboxWatcher.stop()
+  }
+
+  it should "process incoming files" in {
+    val testInbox = TestInbox()
+    val inboxWatcher = new InboxWatcher[File](testInbox)
+
+    inboxWatcher.start()
+
+    // create files after starting watcher
+    val file1: File = (inboxDir / "file1.txt").createFile()
+    val file2: File = (inboxDir / "file2.txt").createFile()
+
+    eventually {
+      testInbox.createdTasks.size shouldBe 2
+
+      // verify the tasks target the correct files
+      testInbox.createdTasks.exists(_.getTarget == file1) shouldBe true
+      testInbox.createdTasks.exists(_.getTarget == file2) shouldBe true
+
+      // verify all tasks' run method has been called
+      (testInbox.createdTasks(0).run _).verify()
+      (testInbox.createdTasks(1).run _).verify()
+    }
+
+    inboxWatcher.stop()
+  }
+
+  it should "process only the actionable files" in {
+    // TestInbox only creates tasks for .txt files
+    val file1: File = (inboxDir / "file1.txt").createFile()
+    val file2: File = (inboxDir / "file2.png").createFile()
+    val file3: File = (inboxDir / "file3.txt").createFile()
+
+    val testInbox = TestInbox()
+    val inboxWatcher = new InboxWatcher[File](testInbox)
+
+    inboxWatcher.start()
+
+    eventually {
+      testInbox.createdTasks.size shouldBe 2
+
+      // verify the tasks target the correct files
+      testInbox.createdTasks.exists(_.getTarget == file1) shouldBe true
+      testInbox.createdTasks.exists(_.getTarget == file3) shouldBe true
+      testInbox.createdTasks.exists(_.getTarget == file2) shouldBe false
+
+      // verify all tasks' run method has been called
+      (testInbox.createdTasks(0).run _).verify()
+      (testInbox.createdTasks(1).run _).verify()
+    }
+
+    inboxWatcher.stop()
+  }
+
+  it should "use the TaskSorter to process tasks in the correct order" in {
+    val file1: File = (inboxDir / "d-file1.txt").createFile()
+    val file2: File = (inboxDir / "c-file2.txt").createFile()
+    val file3: File = (inboxDir / "b-file3.txt").createFile()
+    val file4: File = (inboxDir / "a-file4.txt").createFile()
+
+    val testInbox = TestInbox()
+    val inboxWatcher = new InboxWatcher[File](testInbox)
+
+    // this test task sorter alphabetically sorts the tasks on file name
+    val testTaskSorter = new TaskSorter[File] {
+      override def sort(tasks: List[Task[File]]): List[Task[File]] = {
+        tasks.sortBy(_.getTarget.name)
+      }
+    }
+
+    inboxWatcher.start(Some(testTaskSorter))
+
+    eventually {
+      testInbox.createdTasks.size shouldBe 4
+
+      // verify the tasks have been ran in the correct order
+      val task1 = testInbox.createdTasks.find(_.getTarget == file4).get
+      val task2 = testInbox.createdTasks.find(_.getTarget == file3).get
+      val task3 = testInbox.createdTasks.find(_.getTarget == file2).get
+      val task4 = testInbox.createdTasks.find(_.getTarget == file1).get
+
+      inSequence {
+        (task1.run _).verify()
+        (task2.run _).verify()
+        (task3.run _).verify()
+        (task4.run _).verify()
+      }
+    }
+
+    inboxWatcher.stop()
+  }
+
+  it should "process other tasks if a task fails" in {
+    val file1: File = (inboxDir / "file1.txt").createFile()
+    val file2: File = (inboxDir / "file2.jpg").createFile()
+    val file3: File = (inboxDir / "file3.txt").createFile()
+
+    val testInbox = TestInbox()
+    val inboxWatcher = new InboxWatcher[File](testInbox)
+
+    inboxWatcher.start()
+
+    eventually {
+      testInbox.createdTasks.size shouldBe 3
+
+      // verify the tasks target the correct files
+      testInbox.createdTasks.exists(_.getTarget == file1) shouldBe true
+      testInbox.createdTasks.exists(_.getTarget == file2) shouldBe true
+      testInbox.createdTasks.exists(_.getTarget == file3) shouldBe true
+
+      // verify all tasks' run method has been called
+      (testInbox.createdTasks(0).run _).verify()
+      (testInbox.createdTasks(1).run _).verify()
+      (testInbox.createdTasks(2).run _).verify()
+    }
+
+    inboxWatcher.stop()
+  }
+}

--- a/src/test/scala/nl/knaw/dans/lib/taskqueue/PassiveTaskQueueSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/taskqueue/PassiveTaskQueueSpec.scala
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.taskqueue
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class PassiveTaskQueueSpec extends AnyFlatSpec with Matchers {
+
+  "process" should "cause previously queued tasks to be processed" in {
+    val taskQueue = new PassiveTaskQueue[Any]()
+    val tasks = List(
+      TriggerTask(),
+      TriggerTask(),
+      TriggerTask(),
+    )
+
+    tasks.foreach(taskQueue.add)
+    taskQueue.process()
+
+    tasks(0).triggered shouldBe true
+    tasks(1).triggered shouldBe true
+    tasks(2).triggered shouldBe true
+  }
+
+  it should "cause all other tasks to be processed if one task fails" in {
+    val taskQueue = new PassiveTaskQueue[Any]()
+    val tasks = List(
+      TriggerTask(),
+      TriggerTask(shouldFail = true),
+      TriggerTask(),
+    )
+
+    tasks.foreach(taskQueue.add)
+    taskQueue.process()
+
+    tasks(0).triggered shouldBe true
+    tasks(2).triggered shouldBe true
+  }
+}

--- a/src/test/scala/nl/knaw/dans/lib/taskqueue/PassiveTaskQueueSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/taskqueue/PassiveTaskQueueSpec.scala
@@ -15,17 +15,18 @@
  */
 package nl.knaw.dans.lib.taskqueue
 
+import better.files.File
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class PassiveTaskQueueSpec extends AnyFlatSpec with Matchers {
 
   "process" should "cause previously queued tasks to be processed" in {
-    val taskQueue = new PassiveTaskQueue[Any]()
+    val taskQueue = new PassiveTaskQueue[File]()
     val tasks = List(
-      TriggerTask(),
-      TriggerTask(),
-      TriggerTask(),
+      FileTriggerTask(),
+      FileTriggerTask(),
+      FileTriggerTask(),
     )
 
     tasks.foreach(taskQueue.add)
@@ -37,22 +38,23 @@ class PassiveTaskQueueSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "cause all other tasks to be processed if one task fails" in {
-    val taskQueue = new PassiveTaskQueue[Any]()
+    val taskQueue = new PassiveTaskQueue[File]()
     val tasks = List(
-      TriggerTask(),
-      TriggerTask(shouldFail = true),
-      TriggerTask(),
+      FileTriggerTask(),
+      FileTriggerTask(shouldFail = true),
+      FileTriggerTask(),
     )
 
     tasks.foreach(taskQueue.add)
     taskQueue.process()
 
     tasks(0).triggered shouldBe true
+    tasks(1).triggered shouldBe true
     tasks(2).triggered shouldBe true
   }
 
   it should "not fail on an empty task queue" in {
-    val taskQueue = new PassiveTaskQueue[Any]()
+    val taskQueue = new PassiveTaskQueue[File]()
     taskQueue.process()
   }
 }

--- a/src/test/scala/nl/knaw/dans/lib/taskqueue/PassiveTaskQueueSpec.scala
+++ b/src/test/scala/nl/knaw/dans/lib/taskqueue/PassiveTaskQueueSpec.scala
@@ -50,4 +50,9 @@ class PassiveTaskQueueSpec extends AnyFlatSpec with Matchers {
     tasks(0).triggered shouldBe true
     tasks(2).triggered shouldBe true
   }
+
+  it should "not fail on an empty task queue" in {
+    val taskQueue = new PassiveTaskQueue[Any]()
+    taskQueue.process()
+  }
 }

--- a/src/test/scala/nl/knaw/dans/lib/taskqueue/TriggerTask.scala
+++ b/src/test/scala/nl/knaw/dans/lib/taskqueue/TriggerTask.scala
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.lib.taskqueue
+
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+
+import scala.util.Try
+
+/**
+ *
+ * @param shouldFail if this is set to true the task will throw an exception in the run method
+ */
+case class TriggerTask(shouldFail: Boolean = false) extends Task[Any] with DebugEnhancedLogging {
+  var triggered = false
+
+  override def run(): Try[Unit] = Try {
+    trace(())
+    if (shouldFail) throw new Exception("Task failed")
+    triggered = true
+  }
+
+  override def getTarget: Any = {}
+}


### PR DESCRIPTION
fixes DD-249

#### When applied it will
* Add unit tests for `ActiveTaskQueue`, `PassiveTaskQueue`, and integration tests for the `InboxWatcher` system.

Note that the test `start should process only incoming files` in `InboxSpec` is very slow (10 seconds). This is likely due to a long delay for better.files' `FileMonitor` to respond to the file creation events. Therefore, all other tests in this spec add the files to the inbox directory before starting the inbox watcher.

#### Where should the reviewer @DANS-KNAW/dataversedans start?

#### How should this be manually tested?

#### related pull requests on github
