### PR TITLE
Refactoring TaskQueue classes

### DIFF
--- a/src/main/scala/nl/knaw/dans/lib/taskqueue/AbstractTaskQueue.scala
+++ b/src/main/scala/nl/knaw/dans/lib/taskqueue/AbstractTaskQueue.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.LinkedBlockingDeque
 import scala.util.Try
 
 abstract class AbstractTaskQueue[T] extends TaskQueue[T] with DebugEnhancedLogging {
-  protected val tasks = new LinkedBlockingDeque[Option[Task[T]]]
+  protected val tasks = new LinkedBlockingDeque[Task[T]]
 
   /**
    * Adds a new task to the queue.
@@ -30,12 +30,12 @@ abstract class AbstractTaskQueue[T] extends TaskQueue[T] with DebugEnhancedLoggi
    */
   def add(t: Task[T]): Try[Unit] = Try {
     trace(t)
-    tasks.put(Some(t))
+    tasks.put(t)
     debug("Task added to queue")
   }
 
-  protected def runTask(t: Option[Task[T]]): Boolean = {
-    t.map(_.run().recover {
+  protected def runTask(t: Task[T]): Boolean = {
+    Option(t).map(_.run().recover {
       case e: Throwable => logger.warn(s"Task $t failed", e);
     }).isDefined
   }

--- a/src/main/scala/nl/knaw/dans/lib/taskqueue/ActiveTaskQueue.scala
+++ b/src/main/scala/nl/knaw/dans/lib/taskqueue/ActiveTaskQueue.scala
@@ -15,10 +15,9 @@
  */
 package nl.knaw.dans.lib.taskqueue
 
-import java.util.concurrent.{ Executors, LinkedBlockingDeque }
-
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
+import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 import scala.util.Try
 
@@ -27,20 +26,8 @@ import scala.util.Try
  *
  * @param capacity the maximum capacity of the queue
  */
-class ActiveTaskQueue[T](capacity: Int = 100000) extends TaskQueue[T] with DebugEnhancedLogging {
+class ActiveTaskQueue[T](capacity: Int = 100000) extends AbstractTaskQueue[T] with DebugEnhancedLogging {
   private val executionContext: ExecutionContext = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor())
-  private val tasks = new LinkedBlockingDeque[Option[Task[T]]](capacity)
-
-  /**
-   * Adds a new task to the queue.
-   *
-   * @param t the task to add
-   */
-  def add(t: Task[T]): Try [Unit]  = Try {
-    trace(t)
-    tasks.put(Some(t))
-    debug("Task added to queue")
-  }
 
   /**
    * Starts the queue's processing thread.
@@ -51,12 +38,6 @@ class ActiveTaskQueue[T](capacity: Int = 100000) extends TaskQueue[T] with Debug
       while (runTask(tasks.take())) {}
       logger.info("Finished processing tasks.")
     })
-  }
-
-  private def runTask(t: Option[Task[T]]): Boolean = {
-    t.map(_.run().recover {
-      case e: Throwable => logger.warn(s"Task $t failed", e);
-    }).isDefined
   }
 
   /**

--- a/src/main/scala/nl/knaw/dans/lib/taskqueue/ActiveTaskQueue.scala
+++ b/src/main/scala/nl/knaw/dans/lib/taskqueue/ActiveTaskQueue.scala
@@ -46,6 +46,6 @@ class ActiveTaskQueue[T](capacity: Int = 100000) extends AbstractTaskQueue[T] wi
    */
   def stop(): Try[Unit] = Try {
     tasks.clear()
-    tasks.put(Option.empty[Task[T]])
+    runTask(null)
   }
 }

--- a/src/main/scala/nl/knaw/dans/lib/taskqueue/PassiveTaskQueue.scala
+++ b/src/main/scala/nl/knaw/dans/lib/taskqueue/PassiveTaskQueue.scala
@@ -31,7 +31,8 @@ class PassiveTaskQueue[T]() extends AbstractTaskQueue[T] with DebugEnhancedLoggi
    */
   def process(): Try[Unit] = Try {
     trace(())
-    while (runTask(tasks.take())) {}
+    while (runTask(tasks.poll())) {}
     logger.info("Finished processing tasks.")
   }
+
 }


### PR DESCRIPTION
fixes DD-382

#### When applied it will
* The PassiveTaskQueue will use a LinkedBlockingDeque for task processing. 

#### Where should the reviewer start?

#### How should this be manually tested?
To test the refactoring:
run `mvn clean install`

**Note that if you use jdk11 three tests in `StringExtensionsSpec `will fail. This is because in java 11 String.java has a method `isBlank`. The `dans-scala-lib StringExtensions` also has an `isBlank` method. The failing tests call the java String class now and therefore fail. It may be an idea to open a new issue for this.**

To test the memory leak issue in DD-382 see:
See: https://drivenbydata.atlassian.net/browse/DD-382

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
